### PR TITLE
Cross platform python exit

### DIFF
--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -84,4 +84,7 @@ if len(sys.argv) == 2:
         sys.stdout.write(version)
 else:
     sys.stderr.write(USAGE+'\n')
-    sys.exit(os.EX_USAGE)
+    try:
+        sys.exit(os.EX_USAGE)
+    except AttributeError:
+        sys.exit(1)


### PR DESCRIPTION
Allow for exit from non *nix platforms.

Could use a standardised symbol defined somewhere, but not really worth adding a dependency for this script...
