### PR TITLE
Bug in ManifestManager incorrectly detecting "package.xml" files (unit test attached)

### DIFF
--- a/test/catkin_package_tests/p1/foo/package.xml
+++ b/test/catkin_package_tests/p1/foo/package.xml
@@ -1,0 +1,29 @@
+<package>
+  <name>foo</name>
+  <version>1.2.3</version>
+  <description>
+    I AM THE VERY MODEL OF A MODERN MAJOR GENERAL
+  </description>
+  <maintainer email="someone@example.com">Someone</maintainer>
+
+  <license>BSD</license>
+  <license>LGPL</license>
+
+  <url type="website">http://wiki.ros.org/my_package</url>
+  <url type="bugtracker">http://www.github.com/my_org/my_package/issues</url>
+  <author>John Doe</author>
+  <author email="jane.doe@example.com">Jane Doe</author>
+
+  <build_depend>catkin</build_depend>
+  <build_depend version_gte="1.1" version_lt="2.0">genmsg</build_depend>
+
+  <build_depend>libboost-thread-dev</build_depend>
+  <run_depend>libboost-thread</run_depend>
+
+  <test_depend>gtest</test_depend>
+
+  <conflict>my_old_package</conflict>
+
+  <export>
+  </export>
+</package>

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -1,0 +1,55 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2011, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import os
+import sys
+import time
+import subprocess
+import tempfile
+
+import rospkg
+  
+def test_find_packages():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+
+    manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
+    assert(len(manager.list()) == 0)
+    manager = rospkg.rospack.ManifestManager(rospkg.common.STACK_FILE, ros_paths=[search_path])
+    assert(len(manager.list()) == 0)
+    manager = rospkg.rospack.ManifestManager(rospkg.common.PACKAGE_FILE, ros_paths=[search_path])
+
+    for pkg_name in manager.list():
+        assert(pkg_name == 'foo')
+        path = manager.get_path(pkg_name)
+        assert(path == os.path.join(search_path,'p1','foo'))


### PR DESCRIPTION
ManifestManager incorrectly detects packages with "package.xml" in them as having "manifest.xml" files in them. This patch includes a unit test demonstrating the bug.
