### PR TITLE
Use C version of ElementTree XML parser

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -31,7 +31,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from xml.etree.ElementTree import ElementTree
+from xml.etree.cElementTree import ElementTree
 
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE, ResourceNotFound
 from .environment import get_ros_paths


### PR DESCRIPTION
The C implementation has much better performance.
As rospack/rosdep has to parse a bunch of
package.xml files, this makes a noticeable impact.
