### PR TITLE
Handle malformed XML in manifests

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -74,7 +74,7 @@ def list_by_path(manifest_name, path, cache):
                     del dirs[:]
                     continue #leaf
             except ParseError as e:
-                print ("Warning: Invalid package manifest \"%s\": %s" % (os.path.join(d, PACKAGE_FILE), str(e)), file=sys.stderr)
+                print ('Warning: Invalid package manifest "%s": %s' % (os.path.join(d, PACKAGE_FILE), str(e)), file=sys.stderr)
                 continue
         if manifest_name in files:
             resource_name = basename(d)


### PR DESCRIPTION
A malformed package.xml causes roscore to abort with
a very cryptic error message. As the validity of the
manifests is verified later anyway, we can just issue
a warning in list_by_path(). This gives a nice
InvalidPackage exception from catkin_pkg later.
