### PR TITLE
Location of roscore.xml did change...

### DIFF
--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -43,7 +43,7 @@ def get_distro_name_from_roscore():
     # there's some chance that the location of this file changes in the future
     try:
         roslaunch_dir = rospack.get_path('roslaunch')
-        roscore_file = os.path.join(roslaunch_dir, 'roscore.xml')
+        roscore_file = os.path.join(roslaunch_dir, 'resources', 'roscore.xml')
         if not os.path.exists(roscore_file):
             return None
     except:


### PR DESCRIPTION
This is the location for groovy (hydro the same?).

A better option may be to use [roslib.packages.find_resource](https://github.com/ros/ros/blob/groovy-devel/core/roslib/src/roslib/packages.py), but as remarked, with catkin, this api is not certain (though it is not here either).
