### PR TITLE
Properly decode schrödinger’s (Fedora 19) release name

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -59,7 +59,7 @@ def read_issue(filename="/etc/issue"):
     """
     if os.path.exists(filename):
         with open(filename, 'r') as f:
-            return f.read().split()
+            return f.read().decode('utf8').split()
     return None
 
 class OsNotDetected(Exception):


### PR DESCRIPTION
We need to read the file as UTF8 or we don't get a Python `u''` string back but instead `'schr\xc3\xb6dinger\xe2\x80\x99s'`; this is doomed to fail to match the key in the rosdep .yaml file, which is `u'schr\xf6dinger\u2019s'`.
