### PR TITLE
Use system encoding to read os version

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -38,6 +38,8 @@ from __future__ import print_function
 import os
 import subprocess
 import platform
+import locale
+import codecs
 
 def _read_stdout(cmd):
     try:
@@ -61,7 +63,7 @@ def read_issue(filename="/etc/issue"):
     :returns: list of strings in issue file, or None if issue file cannot be read/split
     """
     if os.path.exists(filename):
-        with open(filename, 'r') as f:
+        with codecs.open(filename, 'r', encoding=locale.getpreferredencoding()) as f:
             return f.read().split()
     return None
 


### PR DESCRIPTION
Fedora 19 brought us the _wonderful_ gift of special characters in the release name. Without specifying the encoding, the release file is read as ASCII (the Python 2 default) and can be wrong. We can use locale to detect the system's preferred encoding and read the file as such.

This problem prevents rosdep or any other ROS entity which uses this value from working correctly in Fedora 19.

locale.getpreferredencoding() was added in Python 2.3.

This should be tested on Ubuntu and OSX, but I can't see how using the system's encoding will result in a different string for OSs where the issue file has none of the extended characters.
