### PR TITLE
check PACKAGE_FILE first, then check if MANIFEST_FILE

### DIFF
--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -363,7 +363,8 @@ def parse_manifest_file(dirpath, manifest_name):
     :raises: :exc:`IOError`
     """
     filename = os.path.join(dirpath, manifest_name)
-    if not os.path.isfile(filename):
+    package_filename = os.path.join(dirpath, PACKAGE_FILE)
+    if os.path.isfile(package_filename):
         # hack for backward compatibility
         package_filename = os.path.join(dirpath, PACKAGE_FILE)
         if not os.path.isfile(package_filename):


### PR DESCRIPTION
current implementation check if there are not exists manifest.xml then use package.xml, this means that rosdep uses manifest.xml if there exist both manifest.xml and package.xml (we mantain both manifest.xml and package.xml for backword compatibility), because current rosdep only works with newer rosdep.yaml  that usually compatible with package.xml not manifest.xml

The patch uses package.xml if exist, then try to read from manifest.xml
