### PR TITLE
Fix test for 32-bit machines

### DIFF
--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -349,7 +349,7 @@ def test_OsDetector():
 def test_tripwire_uname_get_machine():
     from rospkg.os_detect import uname_get_machine
     retval = uname_get_machine()
-    assert retval in [None, 'i386', 'x86_64']
+    assert retval in [None, 'i386', 'i686', 'x86_64']
 
 
 def test_tripwire_rhel():


### PR DESCRIPTION
Current versions of Ubuntu LTS and Fedora will report i686 for the architecture, not i386, making this test fail on 32-bit machines

Test fails on Fedora and Ubuntu 12.04
