### PR TITLE
Fix test for armv7l machines

### DIFF
--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -349,7 +349,7 @@ def test_OsDetector():
 def test_tripwire_uname_get_machine():
     from rospkg.os_detect import uname_get_machine
     retval = uname_get_machine()
-    assert retval in [None, 'i386', 'i686', 'x86_64']
+    assert retval in [None, 'armv7l', 'i386', 'i686', 'ppc', 'ppc64', 'x86_64']
 
 
 def test_tripwire_rhel():


### PR DESCRIPTION
Since ARM is a primary architecture on Fedora, `noarch` packages such as this are often built on ARM machines. `armv7l` is the only supported ARM architecture in Fedora right now, so it is the only one that we require be added to the test for building on Fedora.

Build failure: https://kojipkgs.fedoraproject.org//work/tasks/1855/7141855/build.log
