### PR TITLE
Make LsbDetect check upstream LSB data as well.

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -130,20 +130,10 @@ class LsbDetect(OsDetector):
         raise OsNotDetected('called in incorrect OS')
 
     def load_upstream_info(self, release_file='/etc/upstream-release/lsb-release'):
-        upstream_info = read_issue(filename=release_file)
-        if upstream_info is None:
+        up_os_list = read_issue(filename=release_file)
+        if up_os_list is None or len(up_os_list) < 3:
             return None
-        # use bit of code from lsb_release
-        info = {}
-        for line in upstream_info[:3]:
-            var, arg = line.split('=', 1)
-            if var.startswith('DISTRIB_'):
-                var = var[8:]
-                if arg.startswith('"') and arg.endswith('"'):
-                    arg = arg[1:-1]
-                if arg: # Ignore empty arguments
-                    info[var] = arg
-        return (info['ID'], info['RELEASE'], info['CODENAME'])
+        return [line.split('=')[1] for line in up_os_list[:3]]
 
 class OpenSuse(OsDetector):
     """

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -112,8 +112,7 @@ class LsbDetect(OsDetector):
             self.lsb_info = platform.dist()
         else:
             self.lsb_info = None
-        # use upstream info only if necessary or requested
-        if not self.is_os() or use_upstream:
+        if use_upstream:
             self.lsb_info = self.load_upstream_info()
 
     def is_os(self):
@@ -520,6 +519,7 @@ OS_OSX='osx'
 OS_QNX='qnx'
 OS_RHEL='rhel'
 OS_UBUNTU='ubuntu'
+OS_UBUNTU_DERIVATIVE='ubuntu'
 OS_WINDOWS='windows'
 
 OsDetect.register_default(OS_ARCH, Arch())
@@ -534,6 +534,7 @@ OsDetect.register_default(OS_OSX, OSX())
 OsDetect.register_default(OS_QNX, QNX())
 OsDetect.register_default(OS_RHEL, Rhel())
 OsDetect.register_default(OS_UBUNTU, LsbDetect("Ubuntu"))
+OsDetect.register_default(OS_UBUNTU_DERIVATIVE, LsbDetect("Ubuntu", use_upstream=True))
 OsDetect.register_default(OS_WINDOWS, Windows())    
     
 


### PR DESCRIPTION
First stab at solution for ros-infrastructure/rosdep#272.

Some slight code duplication (copy/paste from `lsb_release`), but it doesn't introduce any new dependencies.

From some googling I understand that `lsb_release` is going to be deprecated (or already is), and `platform.linux_distribution(..)` is transitioning to `/etc/os-release`. iiuc, `platform.linux_distribution(..)` is also (going to be) deprecated.

All tests pass, and my system is correctly identified as:
```
OS Name:     ubuntu
OS Version:  12.04
OS Codename: precise
```