### PR TITLE
add a lock in _update_location_cache

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -163,6 +163,7 @@ class ManifestManager(object):
             return self._load_manifest(name)
 
     def _update_location_cache(self):
+        global _cache_lock
         # ensure self._location_cache is not checked while it is being updated
         # (i.e. while it is not None, but also not completely populated)
         with _cache_lock:


### PR DESCRIPTION
This makes sure `self._location_cache` is not checked while it is updated (i.e. while it is not `None`, but also not completely populated).

Before, multithreaded calls to `get_manifest` would throw exceptions (see https://github.com/RobotWebTools/rosbridge_suite/pull/139 ): 
While Thread 1 is still traversing the paths (line 176), Thread 2 enters `_update_location_cache`, sees that `_location_cache` is not `None` and returns, but `_location cache` doesn't contain data from all paths yet, so a `ResourceNotFound` exception is raised, even though Thread 1 will in fact add the "missing" data eventually.
