### PR TITLE
Add detector to read /etc/os-release

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -67,7 +67,7 @@ def read_issue(filename="/etc/issue"):
             return f.read().split()
     return None
 
-def read_os_release(filename = "/etc/os-release"):
+def read_os_release(filename="/etc/os-release"):
     """
     :returns: Dictonary of key value pairs from /etc/os-release, with quotes stripped from values
     """

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -149,7 +149,7 @@ class FdoDetect(OsDetector):
     """
     def __init__(self, fdo_id):
         release_info = read_os_release()
-        if release_info.has_key("ID") and release_info["ID"] == fdo_id:
+        if release_info is not None and release_info.has_key("ID") and release_info["ID"] == fdo_id:
             self.release_info = release_info
         else:
             self.release_info = None

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -141,11 +141,12 @@ class LsbDetect(OsDetector):
 
 class FdoDetect(OsDetector):
     """
-    Generic detector for operating systems implementing /etc/os-release.
+    Generic detector for operating systems implementing /etc/os-release, as defined by the os-release spec hosted at Freedesktop.org (Fdo):
+    http://www.freedesktop.org/software/systemd/man/os-release.html
     Requires that the "ID", and "VERSION_ID" keys are set in the os-release file.
-    Codename is parsed from VERSION key if available: either using format
-    "foo, CODENAME" or "foo (CODENAME)."
-    If VERSION is not present, the VERSION_ID is returned.
+    
+    Codename is parsed from the VERSION key if available: either using the format "foo, CODENAME" or "foo (CODENAME)."
+    If the VERSION key is not present, the VERSION_ID is value is used as the codename.
     """
     def __init__(self, fdo_id):
         release_info = read_os_release()


### PR DESCRIPTION
Added a detector that reads /etc/os-release and parses names, versions,
and codenames from it.  The name, FdoDetect, is based on
freedesktop.org, where the os-release spec is hosted:
http://www.freedesktop.org/software/systemd/man/os-release.html

Switched the Fedora detector from Fedora to the new FdoDetect

Signed-off-by: Rich Mattes <richmattes@gmail.com>