### PR TITLE
Add more architectures to uname test

### DIFF
--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -365,7 +365,7 @@ def test_OsDetector():
 def test_tripwire_uname_get_machine():
     from rospkg.os_detect import uname_get_machine
     retval = uname_get_machine()
-    assert retval in [None, 'armv7l', 'i386', 'i686', 'ppc', 'ppc64', 'x86_64']
+    assert retval in [None, 'aarch64', 'armv7l', 'i386', 'i686', 'ppc', 'ppc64', 'ppc64le', 's390', 's390x', 'x86_64']
 
 
 def test_tripwire_rhel():


### PR DESCRIPTION
The os-detect test suite enumerates possible results for the uname -m
shell command.  This commit adds a few new architectures to the possible
results list based on Fedora's secondary architectures.

Originally reported at:
https://bugzilla.redhat.com/show_bug.cgi?id=1290136

Signed-off-by: Rich Mattes <richmattes@gmail.com>