### PR TITLE
Set default ROS_PACKAGE_PATH to /usr/share

### DIFF
--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -109,7 +109,7 @@ def get_ros_package_path(env=None):
     """
     if env is None:
         env = os.environ
-    return env.get(ROS_PACKAGE_PATH, None)
+    return env.get(ROS_PACKAGE_PATH, '') + ':/usr/share'
 
 def get_ros_home(env=None):
     """


### PR DESCRIPTION
From @jspricke's [debian patch](http://anonscm.debian.org/cgit/debian-science/packages/ros/ros-rospkg.git/tree/debian/patches/0001-Set-default-ROS_PACKAGE_PATH-to-usr-share.patch)
See also:
https://github.com/vcstools/rosinstall/pull/104
https://github.com/ros-infrastructure/rosinstall_generator/pull/36