### PR TITLE
Limit search in /usr/share

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -89,7 +89,7 @@ def list_by_path(manifest_name, path, cache):
             # optimization for stacks.
             del dirs[:]
             continue #leaf     
-        elif 'rospack_nosubdirs' in files:
+        elif 'rospack_nosubdirs' in files or d.startswith('/usr/share/'):
             del dirs[:]
             continue  #leaf
         # remove hidden dirs (esp. .svn/.git)


### PR DESCRIPTION
os.walk would walk all paths. Let's just use /usr/share/<pkg-name> for
ROS packages.

from @jspricke's [debian patch](http://anonscm.debian.org/cgit/debian-science/packages/ros/ros-rospkg.git/tree/debian/patches/0002-Limit-search-in-usr-share.patch)
See also:
https://github.com/vcstools/rosinstall/pull/104
https://github.com/ros-infrastructure/rosinstall_generator/pull/36
https://github.com/ros-infrastructure/rospkg/pull/99