### PR TITLE
Set rosversion to Debian

### DIFF
--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -75,7 +75,7 @@ if len(sys.argv) == 2:
         else:
             distro_name = get_distro_name_from_roscore()
         if not distro_name:
-            print('<unknown>')
+            print('Debian')
         else:
             print(distro_name)
         sys.exit(0)


### PR DESCRIPTION
From @jspricke's [debian patch](http://anonscm.debian.org/cgit/debian-science/packages/ros/ros-rospkg.git/tree/debian/patches/0003-Set-rosversion-to-Debian.patch)
See also:
https://github.com/vcstools/rosinstall/pull/104
https://github.com/ros-infrastructure/rosinstall_generator/pull/36
https://github.com/ros-infrastructure/rospkg/pull/99
https://github.com/ros-infrastructure/rospkg/pull/100