### PR TITLE
This set's the default ROS_PACKAGE_PATH to /usr/share

### DIFF
--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -52,6 +52,9 @@ ROS_LOG_DIR      ="ROS_LOG_DIR"
 ## directory in which test result files are written
 ROS_TEST_RESULTS_DIR = "ROS_TEST_RESULTS_DIR"
 
+# FHS 4.11 package path
+ROS_SYSTEM_PACKAGE_PATH = "/usr/share"
+
 # Utilities
 def _resolve_path(p):
     """
@@ -115,9 +118,9 @@ def get_ros_package_path(env=None):
         return env.get(ROS_PACKAGE_PATH, None)
 
     if ROS_PACKAGE_PATH in env and env.get(ROS_PACKAGE_PATH):
-        return env.get(ROS_PACKAGE_PATH) + ':/usr/share'
+        return env.get(ROS_PACKAGE_PATH) + ':' + ROS_SYSTEM_PACKAGE_PATH
 
-    return '/usr/share'
+    return ROS_SYSTEM_PACKAGE_PATH
 
 def get_ros_home(env=None):
     """

--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -39,9 +39,10 @@ import os
 # Enviroment Variables
 
 # Global, usually set in setup
-ROS_ROOT         = "ROS_ROOT"
-ROS_PACKAGE_PATH = "ROS_PACKAGE_PATH"
-ROS_HOME         = "ROS_HOME"
+ROS_ROOT            = "ROS_ROOT"
+ROS_PACKAGE_PATH    = "ROS_PACKAGE_PATH"
+ROS_HOME            = "ROS_HOME"
+ROS_RPP_NO_DEFAULTS = "ROS_RPP_NO_DEFAULTS"
 
 # override directory path to /etc/ros
 ROS_ETC_DIR      = "ROS_ETC_DIR"
@@ -109,7 +110,14 @@ def get_ros_package_path(env=None):
     """
     if env is None:
         env = os.environ
-    return env.get(ROS_PACKAGE_PATH, '') + ':/usr/share'
+
+    if ROS_RPP_NO_DEFAULTS in env:
+        return env.get(ROS_PACKAGE_PATH, None)
+
+    if ROS_PACKAGE_PATH in env and env.get(ROS_PACKAGE_PATH):
+        return env.get(ROS_PACKAGE_PATH) + ':/usr/share'
+
+    return '/usr/share'
 
 def get_ros_home(env=None):
     """

--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -53,7 +53,7 @@ ROS_LOG_DIR      ="ROS_LOG_DIR"
 ROS_TEST_RESULTS_DIR = "ROS_TEST_RESULTS_DIR"
 
 # FHS 4.11 package path
-ROS_SYSTEM_PACKAGE_PATH = "/usr/share"
+ROS_SYSTEM_PACKAGE_PATH = "/usr/local/share:/usr/share"
 
 # Utilities
 def _resolve_path(p):

--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -39,10 +39,10 @@ import os
 # Enviroment Variables
 
 # Global, usually set in setup
-ROS_ROOT            = "ROS_ROOT"
-ROS_PACKAGE_PATH    = "ROS_PACKAGE_PATH"
-ROS_HOME            = "ROS_HOME"
-ROS_RPP_NO_DEFAULTS = "ROS_RPP_NO_DEFAULTS"
+ROS_ROOT                     = "ROS_ROOT"
+ROS_PACKAGE_PATH             = "ROS_PACKAGE_PATH"
+ROS_HOME                     = "ROS_HOME"
+ROS_PACKAGE_PATH_NO_DEFAULTS = "ROS_PACKAGE_PATH_NO_DEFAULTS"
 
 # override directory path to /etc/ros
 ROS_ETC_DIR      = "ROS_ETC_DIR"
@@ -111,7 +111,7 @@ def get_ros_package_path(env=None):
     if env is None:
         env = os.environ
 
-    if ROS_RPP_NO_DEFAULTS in env:
+    if ROS_PACKAGE_PATH_NO_DEFAULTS in env:
         return env.get(ROS_PACKAGE_PATH, None)
 
     if ROS_PACKAGE_PATH in env and env.get(ROS_PACKAGE_PATH):

--- a/src/rospkg/environment.py
+++ b/src/rospkg/environment.py
@@ -109,7 +109,7 @@ def get_ros_package_path(env=None):
     """
     if env is None:
         env = os.environ
-    return env.get(ROS_PACKAGE_PATH, None)
+    return env.get(ROS_PACKAGE_PATH, '') + ':/usr/share'
 
 def get_ros_home(env=None):
     """

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -89,7 +89,7 @@ def list_by_path(manifest_name, path, cache):
             # optimization for stacks.
             del dirs[:]
             continue #leaf     
-        elif 'rospack_nosubdirs' in files:
+        elif 'rospack_nosubdirs' in files or d.startswith('/usr/share/'):
             del dirs[:]
             continue  #leaf
         # remove hidden dirs (esp. .svn/.git)

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -35,7 +35,7 @@ from threading import Lock
 from xml.etree.cElementTree import ElementTree
 
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE, ResourceNotFound
-from .environment import get_ros_paths
+from .environment import get_ros_paths, ROS_SYSTEM_PACKAGE_PATH
 from .manifest import parse_manifest_file, InvalidManifest
 from .stack import parse_stack_file, InvalidStack
 
@@ -89,7 +89,7 @@ def list_by_path(manifest_name, path, cache):
             # optimization for stacks.
             del dirs[:]
             continue #leaf     
-        elif 'rospack_nosubdirs' in files or d.startswith('/usr/share/'):
+        elif 'rospack_nosubdirs' in files or d.startswith(ROS_SYSTEM_PACKAGE_PATH):
             del dirs[:]
             continue  #leaf
         # remove hidden dirs (esp. .svn/.git)

--- a/test/test_rospkg_environment.py
+++ b/test/test_rospkg_environment.py
@@ -57,7 +57,7 @@ def test_get_ros_package_path():
     assert '/usr/share' == get_ros_package_path(env={})
     env = {'ROS_PACKAGE_PATH': ':'}
     assert '::/usr/share' == get_ros_package_path(env=env)
-    env = {'ROS_PACKAGE_PATH': ':', 'ROS_RPP_NO_DEFAULTS': 'True'}
+    env = {'ROS_PACKAGE_PATH': ':', 'ROS_PACKAGE_PATH_NO_DEFAULTS': 'True'}
     assert ':' == get_ros_package_path(env=env)
 
     # trip-wire tests. Cannot guarantee that ROS_PACKAGE_PATH is set

--- a/test/test_rospkg_environment.py
+++ b/test/test_rospkg_environment.py
@@ -54,13 +54,13 @@ def test_get_ros_root():
     
 def test_get_ros_package_path():
     from rospkg import get_ros_package_path
-    assert None == get_ros_package_path(env={})
-    env = {'ROS_PACKAGE_PATH': ':'}
-    assert ':' == get_ros_package_path(env=env)
+    assert ':/usr/share' == get_ros_package_path(env={})
+    env = {'ROS_PACKAGE_PATH': ''}
+    assert ':/usr/share' == get_ros_package_path(env=env)
 
     # trip-wire tests. Cannot guarantee that ROS_PACKAGE_PATH is set
     # to valid value on test machine, just make sure logic doesn't crash
-    assert os.environ.get('ROS_PACKAGE_PATH', None) == get_ros_package_path()
+    assert os.environ.get('ROS_PACKAGE_PATH', ':/usr/share') == get_ros_package_path()
 
 def test_get_log_dir():
     from rospkg import get_log_dir, get_ros_root

--- a/test/test_rospkg_environment.py
+++ b/test/test_rospkg_environment.py
@@ -54,15 +54,15 @@ def test_get_ros_root():
     
 def test_get_ros_package_path():
     from rospkg import get_ros_package_path
-    assert '/usr/share' == get_ros_package_path(env={})
+    assert '/usr/local/share:/usr/share' == get_ros_package_path(env={})
     env = {'ROS_PACKAGE_PATH': ':'}
-    assert '::/usr/share' == get_ros_package_path(env=env)
+    assert '::/usr/local/share:/usr/share' == get_ros_package_path(env=env)
     env = {'ROS_PACKAGE_PATH': ':', 'ROS_PACKAGE_PATH_NO_DEFAULTS': 'True'}
     assert ':' == get_ros_package_path(env=env)
 
     # trip-wire tests. Cannot guarantee that ROS_PACKAGE_PATH is set
     # to valid value on test machine, just make sure logic doesn't crash
-    assert os.environ.get('ROS_PACKAGE_PATH', '/usr/share') == get_ros_package_path()
+    assert os.environ.get('ROS_PACKAGE_PATH', '/usr/local/share:/usr/share') == get_ros_package_path()
 
 def test_get_log_dir():
     from rospkg import get_log_dir, get_ros_root

--- a/test/test_rospkg_environment.py
+++ b/test/test_rospkg_environment.py
@@ -54,13 +54,15 @@ def test_get_ros_root():
     
 def test_get_ros_package_path():
     from rospkg import get_ros_package_path
-    assert ':/usr/share' == get_ros_package_path(env={})
-    env = {'ROS_PACKAGE_PATH': ''}
-    assert ':/usr/share' == get_ros_package_path(env=env)
+    assert '/usr/share' == get_ros_package_path(env={})
+    env = {'ROS_PACKAGE_PATH': ':'}
+    assert '::/usr/share' == get_ros_package_path(env=env)
+    env = {'ROS_PACKAGE_PATH': ':', 'ROS_RPP_NO_DEFAULTS': 'True'}
+    assert ':' == get_ros_package_path(env=env)
 
     # trip-wire tests. Cannot guarantee that ROS_PACKAGE_PATH is set
     # to valid value on test machine, just make sure logic doesn't crash
-    assert os.environ.get('ROS_PACKAGE_PATH', ':/usr/share') == get_ros_package_path()
+    assert os.environ.get('ROS_PACKAGE_PATH', '/usr/share') == get_ros_package_path()
 
 def test_get_log_dir():
     from rospkg import get_log_dir, get_ros_root


### PR DESCRIPTION
Initially I created these for Debian, but it should be fine to include
them upstream as well.

Replaces: #99, #100
