### PR TITLE
support and tests for slackware linux

### DIFF
--- a/doc/os_detect.rst
+++ b/doc/os_detect.rst
@@ -27,6 +27,7 @@ Currently supported OSes:
 - Mint
 - OS X
 - Red Hat Linux
+- Slackware 
 - Ubuntu
 
 
@@ -139,6 +140,10 @@ OS name definitions
 .. data:: OS_RHEL
 
    Name used for Red Hat Enterprise Linux.
+
+.. data:: OS_SLACKWARE
+
+   Name used for Slackware.
 
 .. data:: OS_UBUNTU
 

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -485,6 +485,27 @@ class FreeBSD(OsDetector):
             return ''
         raise OsNotDetected('called in incorrect OS')        
 
+class Slackware(OsDetector):
+    """
+    Detect SlackWare Linux.
+    """
+    def __init__(self, release_file='/etc/slackware-version'):
+        self._release_file = release_file
+
+    def is_os(self):
+        return os.path.exists(self._release_file)
+
+    def get_version(self):
+        if self.is_os():
+            os_list = read_issue(self._release_file)
+            return os_list[1]
+        raise OsNotDetected('called in incorrect OS')        
+
+    def get_codename(self):
+        if self.is_os():
+            return ''
+        raise OsNotDetected('called in incorrect OS') 
+
 class Windows(OsDetector):
     """
     Detect Windows OS.
@@ -626,6 +647,7 @@ OS_OPENSUSE13='opensuse'
 OS_OSX='osx'
 OS_QNX='qnx'
 OS_RHEL='rhel'
+OS_SLACKWARE='slackware'
 OS_UBUNTU='ubuntu'
 OS_WINDOWS='windows'
 
@@ -645,6 +667,7 @@ OsDetect.register_default(OS_OPENSUSE13, OpenSuse(brand_file='/etc/SUSE-brand'))
 OsDetect.register_default(OS_OSX, OSX())
 OsDetect.register_default(OS_QNX, QNX())
 OsDetect.register_default(OS_RHEL, Rhel())
+OsDetect.register_default(OS_SLACKWARE, Slackware())
 OsDetect.register_default(OS_UBUNTU, LsbDetect("Ubuntu"))
 OsDetect.register_default(OS_WINDOWS, Windows())
 

--- a/test/os_detect/slackware/slackware-version
+++ b/test/os_detect/slackware/slackware-version
@@ -1,0 +1,1 @@
+Slackware 14.2

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -409,6 +409,35 @@ def test_redhat():
             pass
 
 
+def test_tripwire_slackware():
+    from rospkg.os_detect import OsDetect
+    os_detect = OsDetect()
+    os_detect.get_detector('slackware')
+
+
+def test_slackware():
+    from rospkg.os_detect import Slackware, OsNotDetected
+    test_dir = os.path.join(get_test_dir(), 'slackware')
+    detect = Slackware(os.path.join(test_dir, "slackware-version"))
+    assert detect.is_os()
+    assert detect.get_version() == '14.2'
+    assert detect.get_codename() == ''
+
+    # test freely
+    detect = Slackware()
+    if not detect.is_os():
+        try:
+            detect.get_version()
+            assert False
+        except OsNotDetected:
+            pass
+        try:
+            detect.get_codename()
+            assert False
+        except OsNotDetected:
+            pass
+
+
 def test_tripwire_freebsd():
     from rospkg.os_detect import OsDetect
     os_detect = OsDetect()


### PR DESCRIPTION
Added support for Slackware Linux and tested it as required. See attached file for the log from testing. 
[rospkg_slackware_log.txt](https://github.com/ros-infrastructure/rospkg/files/443009/rospkg_slackware_log.txt)

