### PR TITLE
Add macOS Sierra to _osx_codename_map

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -298,7 +298,8 @@ _osx_codename_map = {4: 'tiger',
                      8: 'mountain lion',
                      9: 'mavericks',
                      10: 'yosemite',
-                     11: 'el capitan'}
+                     11: 'el capitan',
+                     12: 'sierra'}
 def _osx_codename(major, minor):
     if major != 10 or minor not in _osx_codename_map:
         raise OsNotDetected("unrecognized version: %s.%s"%(major, minor))


### PR DESCRIPTION
This will fix `Rosdep experienced an error: unrecognized version: 10.12` error on macOS Sierra using homebrew.

Tested on macOS Sierra 10.12 Beta (16A313a)