### PR TITLE
metadata and build script tweaks so it will build with modern catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 2.8.0)
 project(rospkg)
-find_package(catkin)
-catkin_stack()
-catkin_project(rospkg
-  )
+find_package(catkin REQUIRED)
+catkin_package()
 catkin_python_setup()
 
-install(FILES stack.yaml DESTINATION share/${PROJECT_NAME})
+#install(FILES stack.yaml DESTINATION share/${PROJECT_NAME})
 
-add_nosetests(${PROJECT_SOURCE_DIR})
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package>
+  <name>rospkg</name>
+  <version>1.0.39</version>
+  <description>
+    Standalone Python library for the ROS package system.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>BSD</license>
+  <url type="website">http://www.ros.org/wiki/rospkg</url>
+  <author>Ken Conley</author>
+  <buildtool_depend version_gte="0.5.74">catkin</buildtool_depend>
+  <run_depend>catkin</run_depend>
+  <export>
+    <rosdoc config="rosdoc.yaml"/>
+  </export>
+</package>


### PR DESCRIPTION
These tweaks to the CMakeLists.txt file and adding a minimal package.xml allow rospkg to build using "catkin build" which is convenient when you want to tinker with rospkg without messing up the system-installed version. :chicken:   I'm just proposing this to go on the sros branch for now, since I don't really understand all the implications of this tinkering.