### PR TITLE
set default Debian-Version

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [rospkg]
+Debian-Version: 100
 Depends: python-rospkg-modules
 Depends3: python3-rospkg-modules
 Conflicts: python3-rospkg


### PR DESCRIPTION
Requires ros-infrastructure/ros_release_python#20.