### PR TITLE
os_detect: add Debian Stretch support.

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -158,6 +158,8 @@ class Debian(LsbDetect):
                 return 'wheezy'
             if v.startswith('8.'):
                 return 'jessie'
+            if v.startswith('9.'):
+                return 'stretch'
             return ''
 
 


### PR DESCRIPTION
As per subject.

Reported in [Debian Jessie ROS Install - Dependencies issues](http://answers.ros.org/question/239761) on ROS Answers.
