### PR TITLE
os_detect: add support for openSUSE Leap 42.x and Tumbleweed

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -616,6 +616,7 @@ class OsDetect:
                     self._os_version = os_detector.get_version()
                     self._os_codename = os_detector.get_codename()
                     self._os_detector = os_detector
+                    break
 
         if self._os_name:
             return self._os_name, self._os_version, self._os_codename
@@ -704,6 +705,7 @@ OsDetect.register_default(OS_MINT, LsbDetect("LinuxMint"))
 OsDetect.register_default(OS_NEON, LsbDetect("neon"))
 OsDetect.register_default(OS_OPENSUSE, OpenSuse())
 OsDetect.register_default(OS_OPENSUSE13, OpenSuse(brand_file='/etc/SUSE-brand'))
+OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
 OsDetect.register_default(OS_OSX, OSX())
 OsDetect.register_default(OS_QNX, QNX())
 OsDetect.register_default(OS_RHEL, Rhel())


### PR DESCRIPTION
`/etc/SuSE-release` has been deprecated since openSUSE Leap 42.x.
```
~$ cat /etc/SUSE-brand 
openSUSE
VERSION = 42.1
~$ cat /etc/SuSE-release 
openSUSE 42.3 (x86_64)
VERSION = 42.3
CODENAME = Malachite
# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
~$ cat /etc/os-release 
NAME="openSUSE Leap"
VERSION="42.3"
ID=opensuse
ID_LIKE="suse"
VERSION_ID="42.3"
PRETTY_NAME="openSUSE Leap 42.3"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:42.3"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```

 openSUSE Tumbleweed has removed `/etc/SuSE-release` .
```
~$ cat /etc/SUSE-brand
openSUSE
VERSION = 13.3
~$ cat /etc/os-release 
NAME="openSUSE Tumbleweed"
# VERSION="20170810"
ID=opensuse
ID_LIKE="suse"
VERSION_ID="20170810"
PRETTY_NAME="openSUSE Tumbleweed"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:tumbleweed:20170810"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```