### PR TITLE
[rosversion] Option to remove new line at the end of the line.

### DIFF
--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -29,6 +29,7 @@
 
 from __future__ import print_function
 
+import argparse
 import os
 import sys
 import traceback
@@ -37,7 +38,7 @@ import rospkg
 from rospkg.common import PACKAGE_FILE
 from rospkg.rospack import ManifestManager
 
-USAGE = "Usage: rosversion <package/stack> or rosversion -d"
+USAGE = """Returns the version of the given package, or the distribution version of ROS."""
 
 
 # for < fuerte, retrieve from roscore file
@@ -68,47 +69,75 @@ def get_distro_name_from_roscore():
         traceback.print_exc()
 
 
-if len(sys.argv) == 2:
-    stack_name = sys.argv[1]
-
-    if stack_name == '-d' or stack_name == '--distro':
-        if 'ROS_DISTRO' in os.environ:
-            distro_name = os.environ['ROS_DISTRO']
-        else:
-            distro_name = get_distro_name_from_roscore()
-        if not distro_name:
-            print('<unknown>')
-        else:
-            print(distro_name)
-        sys.exit(0)
-
-    rosstack = rospkg.RosStack()
-    try:
-        version = rosstack.get_stack_version(stack_name)
-    except rospkg.ResourceNotFound as e:
-        try:
-            # hack to make it work with wet packages
-            mm = ManifestManager(PACKAGE_FILE)
-            path = mm.get_path(stack_name)
-            package_manifest = os.path.join(path, 'package.xml')
-            if os.path.exists(package_manifest):
-                from xml.etree.ElementTree import ElementTree
-                try:
-                    root = ElementTree(None, package_manifest)
-                    version = root.findtext('version')
-                except Exception:
-                    pass
-        except rospkg.ResourceNotFound as e:
-            print("Cannot locate [%s]" % (stack_name))
-            sys.exit(1)
-
-    if version is None:
-        print('<unversioned>')
+def get_version_printer(skipnewline=False):
+    """
+    @return: A method object to print the version string.
+    """
+    if skipnewline:
+        return sys.stderr.write
     else:
-        print(version)
-else:
-    print(USAGE)
+        return print
+
+parser = argparse.ArgumentParser(description=USAGE)
+if len(sys.argv) < 2:
+    parser.print_usage()
+    sys.exit(1)
+group = parser.add_mutually_exclusive_group()
+group.add_argument(
+    'package',
+    help="Package name. This name must be in ROS format, not OS package format. "
+         "E.g. CORRECT: roscpp, INCORRECT ros-kinetic-roscpp. See ROS naming "
+         "convention http://wiki.ros.org/ROS/Patterns/Conventions#Packages",
+    nargs='?')
+group.add_argument(
+    '-d', '--distro',
+    help="No argument needed. With this, ROS distribution will be returned.",
+    action='store_true')
+parser.add_argument(
+    "-s", "--skipnewline",
+    help="Skip trailing new line",
+    action='store_true')
+
+args = parser.parse_args()
+            
+version_printer = print
+
+if args.skipnewline:
+    version_printer = get_version_printer(skipnewline=True)
+
+if args.distro:
+    if 'ROS_DISTRO' in os.environ:
+        distro_name = os.environ['ROS_DISTRO']
+    else:
+        distro_name = get_distro_name_from_roscore()
+    if not distro_name:
+        version_printer('<unknown>')
+    else:
+        version_printer(distro_name)
+    sys.exit(0)
+
+stack_name = args.package
+rosstack = rospkg.RosStack()
+try:
+    version = rosstack.get_stack_version(stack_name)
+except rospkg.ResourceNotFound as e:
     try:
-        sys.exit(os.EX_USAGE)
-    except AttributeError:
+        # hack to make it work with wet packages
+        mm = ManifestManager(PACKAGE_FILE)
+        path = mm.get_path(stack_name)
+        package_manifest = os.path.join(path, 'package.xml')
+        if os.path.exists(package_manifest):
+            from xml.etree.ElementTree import ElementTree
+            try:
+                root = ElementTree(None, package_manifest)
+                version = root.findtext('version')
+            except Exception:
+                pass
+    except rospkg.ResourceNotFound as e:
+        print("Cannot locate [%s]" % (stack_name))
         sys.exit(1)
+
+if version is None:
+    version_printer('<unversioned>')
+else:
+    version_printer(version)

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -73,7 +73,9 @@ def print_without_newline(argtext):
 
 
 parser = argparse.ArgumentParser(
-    description='Output the version of the given package, or the ROS distribution name.')
+    description='rosversion -d: Output the version of the given package\n'
+    'rosversion package: ROS distribution name',
+    formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument(
     '-s', '--skip-newline', action='store_true',
     help='Skip trailing newline')

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -67,40 +67,27 @@ def get_distro_name_from_roscore():
         traceback.print_exc()
 
 
-def print_nonewline(argtext):
-    """
-    @summary print with no new line.
-    """
-    print(argtext, end="")
+def print_without_newline(argtext):
+    """Print with no new line."""
+    print(argtext, end='')
 
 
 parser = argparse.ArgumentParser(
     description='Output the version of the given package, or the ROS distribution name.)
-if len(sys.argv) < 2:
-    parser.print_usage()
-    sys.exit(1)
-group = parser.add_mutually_exclusive_group()
-group.add_argument(
-    'package',
-    help="Package name. This name must be in ROS format, not OS package format. "
-         "E.g. CORRECT: roscpp, INCORRECT ros-kinetic-roscpp. See ROS naming "
-         "convention http://wiki.ros.org/ROS/Patterns/Conventions#Packages",
-    nargs='?')
-group.add_argument(
-    '-d', '--distro',
-    help="No argument needed. With this, ROS distribution will be returned.",
-    action='store_true')
 parser.add_argument(
-    "-s", "--skipnewline",
-    help="Skip trailing new line",
-    action='store_true')
+    '-s', '--skip-newline', action='store_true',
+    help='Skip trailing newline')
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument(
+    'package', nargs='?',
+    help="The ROS package name (e.g. 'rclcpp')")
+group.add_argument(
+    '-d', '--distro', action='store_true',
+    help='Output the ROS distribution name')
 
 args = parser.parse_args()
             
-version_printer = print
-
-if args.skipnewline:
-    version_printer = print_nonewline
+printer = print_without_newline if args.skip_newline else print
 
 if args.distro:
     if 'ROS_DISTRO' in os.environ:
@@ -108,20 +95,18 @@ if args.distro:
     else:
         distro_name = get_distro_name_from_roscore()
     if not distro_name:
-        version_printer('<unknown>')
-    else:
-        version_printer(distro_name)
+        distro_name = '<unknown>'
+    printer(distro_name)
     sys.exit(0)
 
-stack_name = args.package
 rosstack = rospkg.RosStack()
 try:
-    version = rosstack.get_stack_version(stack_name)
+    version = rosstack.get_stack_version(args.package)
 except rospkg.ResourceNotFound as e:
     try:
         # hack to make it work with wet packages
         mm = ManifestManager(PACKAGE_FILE)
-        path = mm.get_path(stack_name)
+        path = mm.get_path(args.package)
         package_manifest = os.path.join(path, 'package.xml')
         if os.path.exists(package_manifest):
             from xml.etree.ElementTree import ElementTree
@@ -131,10 +116,9 @@ except rospkg.ResourceNotFound as e:
             except Exception:
                 pass
     except rospkg.ResourceNotFound as e:
-        print("Cannot locate [%s]" % (stack_name))
+        print('Cannot locate [%s]' % args.package)
         sys.exit(1)
 
 if version is None:
-    version_printer('<unversioned>')
-else:
-    version_printer(version)
+    version = '<unversioned>'
+printer(version)

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -80,7 +80,7 @@ parser.add_argument(
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument(
     'package', nargs='?',
-    help="The ROS package name (e.g. 'rclcpp')")
+    help="The ROS package name (e.g. 'roscpp')")
 group.add_argument(
     '-d', '--distro', action='store_true',
     help='Output the ROS distribution name')

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -38,8 +38,6 @@ import rospkg
 from rospkg.common import PACKAGE_FILE
 from rospkg.rospack import ManifestManager
 
-USAGE = """Returns the version of the given package, or the distribution version of ROS."""
-
 
 # for < fuerte, retrieve from roscore file
 def get_distro_name_from_roscore():
@@ -76,7 +74,8 @@ def print_nonewline(argtext):
     print(argtext, end="")
 
 
-parser = argparse.ArgumentParser(description=USAGE)
+parser = argparse.ArgumentParser(
+    description='Output the version of the given package, or the ROS distribution name.)
 if len(sys.argv) < 2:
     parser.print_usage()
     sys.exit(1)

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -74,7 +74,7 @@ def print_without_newline(argtext):
 
 parser = argparse.ArgumentParser(
     description='rosversion -d: Output the version of the given package\n'
-    'rosversion package: ROS distribution name',
+    'rosversion package: Output the ROS distribution name',
     formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument(
     '-s', '--skip-newline', action='store_true',

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -69,14 +69,12 @@ def get_distro_name_from_roscore():
         traceback.print_exc()
 
 
-def get_version_printer(skipnewline=False):
+def print_nonewline(argtext):
     """
-    @return: A method object to print the version string.
+    @summary print with no new line.
     """
-    if skipnewline:
-        return sys.stderr.write
-    else:
-        return print
+    print(argtext, end="")
+
 
 parser = argparse.ArgumentParser(description=USAGE)
 if len(sys.argv) < 2:
@@ -103,7 +101,7 @@ args = parser.parse_args()
 version_printer = print
 
 if args.skipnewline:
-    version_printer = get_version_printer(skipnewline=True)
+    version_printer = print_nonewline
 
 if args.distro:
     if 'ROS_DISTRO' in os.environ:

--- a/scripts/rosversion
+++ b/scripts/rosversion
@@ -73,7 +73,7 @@ def print_without_newline(argtext):
 
 
 parser = argparse.ArgumentParser(
-    description='Output the version of the given package, or the ROS distribution name.)
+    description='Output the version of the given package, or the ROS distribution name.')
 parser.add_argument(
     '-s', '--skip-newline', action='store_true',
     help='Skip trailing newline')

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [rospkg]
 Debian-Version: 100
-Depends: python-catkin-pkg, python-rospkg-modules
-Depends3: python3-catkin-pkg, python3-rospkg-modules
+Depends: python-argparse, python-catkin-pkg, python-rospkg-modules
+Depends3: python-argparse, python3-catkin-pkg, python3-rospkg-modules
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [rospkg]
 Debian-Version: 100
 Depends: python-argparse, python-catkin-pkg, python-rospkg-modules
-Depends3: python-argparse, python3-catkin-pkg, python3-rospkg-modules
+Depends3: python3-catkin-pkg, python3-rospkg-modules
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster


### PR DESCRIPTION
Partially addresses https://github.com/ros/ros_comm/issues/1064

```
RUMER@paella$ ./scripts/rosversion
Usage:
rosversion <package/stack> [option]
rosversion -d [option]

Option:
-n: Add no new line at the end of the output line.

RUMER@paella$ ./scripts/rosversion -d
kinetic
RUMER@paella$ ./scripts/rosversion -d -n
kineticRUMER@paella$ ./scripts/rosversion roslaunch
1.12.12
RUMER@paella$ ./scripts/rosversion roslaunch -n
1.12.12RUMER@paella$
```