### PR TITLE
Fix get_{depends, rosdeps} error when depended pkgs are not available in the environment

### DIFF
--- a/src/rospkg/common.py
+++ b/src/rospkg/common.py
@@ -45,15 +45,21 @@ class ResourceNotFound(Exception):
     A ROS filesystem resource was not found.
     """
 
-    def __init__(self, msg, ros_paths=None, list_deps_sofar=None):
+    def __init__(self, msg, ros_paths=None, deps_sofar=None, deps_unavailable=None):
         """
-        :type list_deps_sofar: [str]
-        :param list_deps_sofar: List of depended packages at the time the command
-                                               stopped due to this exception.
+        :type deps_sofar: [str]
+        :param deps_sofar: List of depended packages at the time the command
+                           stopped due to this exception.
+        :type deps_unavailable: [str]
+        :param deps_unavailable: List of packages defined in the dependency but are not
+                                 available on the platform.
         """
         super(ResourceNotFound, self).__init__(msg)
         self.ros_paths = ros_paths
-        self.list_deps_sofar = list_deps_sofar
+        self.deps_sofar = deps_sofar
+        self.deps_unavailable = set()
+        if deps_unavailable:
+            self.deps_unavailable.update(deps_unavailable)
 
     def __str__(self):
         s = self.args[0]  # python 2.6
@@ -61,3 +67,6 @@ class ResourceNotFound(Exception):
             for i, p in enumerate(self.ros_paths):
                 s = s + '\nROS path [%s]=%s' % (i, p)
         return s
+
+    def get_depends(self):
+        return self.deps_sofar

--- a/src/rospkg/common.py
+++ b/src/rospkg/common.py
@@ -45,9 +45,15 @@ class ResourceNotFound(Exception):
     A ROS filesystem resource was not found.
     """
 
-    def __init__(self, msg, ros_paths=None):
+    def __init__(self, msg, ros_paths=None, list_deps_sofar=None):
+        """
+        :type list_deps_sofar: [str]
+        :param list_deps_sofar: List of depended packages at the time the command
+                                               stopped due to this exception.
+        """
         super(ResourceNotFound, self).__init__(msg)
         self.ros_paths = ros_paths
+        self.list_deps_sofar = list_deps_sofar
 
     def __str__(self):
         s = self.args[0]  # python 2.6

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -126,7 +126,6 @@ class ManifestManager(object):
 
         self._manifests = {}
         self._depends_cache = {}
-        self._depends_unavailable = []
         self._rosdeps_cache = {}
         self._location_cache = None
         self._custom_cache = {}
@@ -165,10 +164,7 @@ class ManifestManager(object):
         if name in self._manifests:
             return self._manifests[name]
         else:
-            try:
-                return self._load_manifest(name)
-            except ResourceNotFound as e:
-                raise e
+            return self._load_manifest(name)
 
     def _update_location_cache(self):
         global _cache_lock
@@ -212,11 +208,7 @@ class ManifestManager(object):
         """
         :raises: :exc:`ResourceNotFound`
         """
-        retval = None
-        try:
-            retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
-        except ResourceNotFound as e:
-            raise e
+        retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
         return retval
 
     def get_depends(self, name, implicit=True):
@@ -241,14 +233,15 @@ class ManifestManager(object):
             # assign key before recursive call to prevent infinite case
             self._depends_cache[name] = s = set()
 
+            depends_unavailable = set()
+
             # take the union of all dependencies
             names = None
             try:
                 names = [p.name for p in self.get_manifest(name).depends]
             except ResourceNotFound as e:
                 del self._depends_cache[name]
-                self._depends_unavailable.append(name)
-                e.list_deps_sofar = self._depends_unavailable
+                e.deps_unavailable.add(name)
                 raise e
 
             for p in names:
@@ -256,21 +249,24 @@ class ManifestManager(object):
                 try:
                     deps = self.get_depends(p, implicit)
                 except ResourceNotFound as e:
-                    deps = e.list_deps_sofar
-                s.update(deps)
+                    deps = e.get_depends()
+                    depends_unavailable.update(e.deps_unavailable)
+                if deps:
+                    s.update(deps)
             # add in our own deps
             s.update(names)
             # cache the return value as a list
             s = list(s)
             self._depends_cache[name] = s
-            if 0 < len(self._depends_unavailable) or 0 == len(s):
+            if 0 < len(depends_unavailable) or 0 == len(s):
                 raise ResourceNotFound(
-                    "Pkg(s) {} not available on your environment.\n"
+                    "Pkg(s) {0} not available on your environment.\n"
                     "Defined dependency can be obtained in "
-                    "ResourceNotFound.list_deps_sofar: {}".format(
-                        self._depends_unavailable, s),
+                    "ResourceNotFound.get_depends: {1}".format(
+                        list(depends_unavailable), s),
                     ros_paths=self._ros_paths,
-                    list_deps_sofar=s)
+                    deps_sofar=s,
+                    deps_unavailable=depends_unavailable)
             return s
 
     def get_depends_on(self, name, implicit=True):

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -386,9 +386,18 @@ class RosPack(ManifestManager):
         self._rosdeps_cache[package] = s = set()
 
         # take the union of all dependencies
-        packages = self.get_depends(package, implicit=True)
-        for p in packages:
-            s.update(self.get_rosdeps(p, implicit=False))
+        packages = []
+        try:
+            packages = self.get_depends(package, implicit=True)
+        except ResourceNotFound as e:
+            del self._rosdeps_cache[package]
+            packages = e.get_depends()
+        if packages:
+            for p in packages:
+                try:
+                    s.update(self.get_rosdeps(p, implicit=False))
+                except ResourceNotFound as e:
+                    print("Not available in your environment: {}".format(str(e)))
         # add in our own deps
         m = self.get_manifest(package)
         s.update([d.name for d in m.rosdeps])

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -246,6 +246,7 @@ class ManifestManager(object):
             try:
                 names = [p.name for p in self.get_manifest(name).depends]
             except ResourceNotFound as e:
+                del self._depends_cache[name]
                 self._depends_unavailable.append(name)
                 e.list_deps_sofar = self._depends_unavailable
                 raise e

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -58,3 +58,27 @@ def test_get_manifest():
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
+
+
+def test_get_rosdeps_rsc_nonexistent():
+    """
+    @summary: get_rosdeps needs to raise rospkg.ResourceNotFound every time
+                          a non-existent package is passed.
+    """
+    search_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    # Need to run get_rosdeps twice and both must raise the same exception.
+    # https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083
+    try:  # 1st run
+        manager.get_rosdeps("pkg_nonexistent")
+    except rospkg.ResourceNotFound as e:
+        pass
+
+    try:  # 2nd run
+        manager.get_rosdeps("pkg_nonexistent")
+    except rospkg.ResourceNotFound as e:
+        pass
+    else:
+        print("ResourceNotFound expected but wasn't raised. Failure.")
+        assert(False)


### PR DESCRIPTION
UPDATED issue description.

**Issue**

When some dependencies are not available on the environment, the following problems can occur for `RosPack.get_{depends, rosdeps}`:
- For a package available on your environment (e.g. `roscpp`), 1st invocation fails without printing the dependency. But 2nd invocation returns a list of dependencies.
- `get_depends`'s error message does not list all missing pkgs; in the example below, what's actually missing on the environment are `roslang` and `rosunit`, but it only shows rosunit. Each invocation lists only a single package missing.
- `get_rosdeps` returns an empty set (set()) on the 2nd invocation when there is more than one package unavailable on your environment (e.g. `foo` as reported originally at https://github.com/ros-infrastructure/rospkg/pull/129#issuecomment-364307544).

**Current output**

```
$ apt-cache policy python-rospkg
python-rospkg:
  Installed: 1.1.4-100
  Candidate: 1.1.4-100

$ env|grep -i pythonpath
PYTHONPATH=/opt/ros/kinetic/lib/python2.7/dist-packages
$ ipython
In [1]: from rospkg import RosPack
In [2]: rp = RosPack()
In [3]: rp.get_depends("roscpp")
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-3996ba0273da> in <module>()
----> 1 rp.get_depends("roscpp")

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    238
    239             for p in names:
--> 240                 s.update(self.get_depends(p, implicit))
    241             # add in our own deps
    242             s.update(names)

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    238
    239             for p in names:
--> 240                 s.update(self.get_depends(p, implicit))
    241             # add in our own deps
    242             s.update(names)

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    232
    233             # take the union of all dependencies
--> 234             names = [p.name for p in self.get_manifest(name).depends]
    235
    236             # assign key before recursive call to prevent infinite case

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_manifest(self, name)
    165             return self._manifests[name]
    166         else:
--> 167             return self._load_manifest(name)
    168
    169     def _update_location_cache(self):

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in _load_manifest(self, name)
    209         :raises: :exc:`ResourceNotFound`
    210         """
--> 211         retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
    212         return retval
    213

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_path(self, name)
    201         self._update_location_cache()
    202         if name not in self._location_cache:
--> 203             raise ResourceNotFound(name, ros_paths=self._ros_paths)
    204         else:
    205             return self._location_cache[name]

ResourceNotFound: rosunit
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/opt/ros/kinetic/share
```
```
In [1]: from rospkg import RosPack
In [2]: rp = RosPack()
In [3]: rp.get_rosdeps("roscpp")                                                                                                                                                                           
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-d0c5947c660f> in <module>()
----> 1 rp.get_rosdeps("roscpp")
:
ResourceNotFound: roslang
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/opt/ros/kinetic/share

In [4]: rp.get_rosdeps("roscpp")
Out[4]: set()
```


**Solution**

- Returns the list of all dependency.
- Warn what's missing on your environment.

**Output of suggested change**

```
In [1]: from rospkg import RosPack
In [2]: rp = RosPack()
In [3]: rp.get_depends("roscpp")
[WARN] Depended package not available on your environment: rosunit
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/opt/ros/kinetic/share
[WARN] Depended package not available on your environment: roslang
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/opt/ros/kinetic/share
Out[3]:
['rosgraph_msgs',
 'genlisp',
 'genpy',
 'genmsg',
 'catkin',
 'rosconsole',
 'gencpp',
 'xmlrpcpp',
 'rostime',
 'roslang',
 'message_runtime',
 'std_msgs',
 'geneus',
 'gennodejs',
 'roscpp_traits',
 'roscpp_serialization',
 'rosbuild',
 'message_generation',
 'cpp_common',
 'rosunit']
```
