### PR TITLE
Add "get_licenses" method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
 install:
 # develop seems to be required by travis since 02/2013
   - python setup.py build develop
-  - pip install nose coverage
+  - pip install nose coverage rosdep
+  - sudo `which rosdep` init
+  - rosdep update
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=rospkg --with-xunit test

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -334,6 +334,7 @@ class Manifest(object):
             self.version = self.notes = ''
         self.licenses = []
         self.depends = []
+        self.licenses = []
         self.rosdeps = []
         self.exports = []
         self.platforms = []

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -42,7 +42,7 @@ import xml.dom.minidom as dom
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE
 
 # stack.xml and manifest.xml have the same internal tags right now
-REQUIRED = ['license']
+REQUIRED = ['license', "name"]
 ALLOWXHTML = ['description']
 OPTIONAL = ['author', 'logo', 'url', 'brief', 'description', 'status',
             'notes', 'depend', 'rosdep', 'export', 'review',
@@ -318,7 +318,7 @@ class Manifest(object):
         'author', 'license', 'licenses', 'license_url', 'url',
         'depends', 'rosdeps', 'platforms',
         'exports', 'version',
-        'status', 'notes',
+        'status', 'name', 'notes',
         'unknown_tags', 'type', 'filename',
         'is_catkin']
 
@@ -396,6 +396,7 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
         p = parse_package(package_filename)
         # put these into manifest
         manifest.description = p.description
+        manifest.name = p.name
         manifest.author = ', '.join([('Maintainer: %s' % str(m)) for m in p.maintainers] + [str(a) for a in p.authors])
         manifest.license = ', '.join(p.licenses)
         manifest.licenses = p.licenses
@@ -499,6 +500,7 @@ def parse_manifest(manifest_name, string, filename='string'):
         pass  # manifest is missing optional 'review notes' tag
 
     m.author = _check('author', True)(p, filename)
+    m.name = _check("name")(p, filename)
     m.url = _check('url')(p, filename)
     m.version = _check('version')(p, filename)
 

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -42,7 +42,7 @@ import xml.dom.minidom as dom
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE
 
 # stack.xml and manifest.xml have the same internal tags right now
-REQUIRED = ['license', "name"]
+REQUIRED = ['license', 'name']
 ALLOWXHTML = ['description']
 OPTIONAL = ['author', 'logo', 'url', 'brief', 'description', 'status',
             'notes', 'depend', 'rosdep', 'export', 'review',
@@ -501,7 +501,7 @@ def parse_manifest(manifest_name, string, filename='string'):
         pass  # manifest is missing optional 'review notes' tag
 
     m.author = _check('author', True)(p, filename)
-    m.name = _check("name")(p, filename)
+    m.name = _check('name')(p, filename)
     m.url = _check('url')(p, filename)
     m.version = _check('version')(p, filename)
 

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -389,10 +389,11 @@ class RosPack(ManifestManager):
             else:
                 d = os.path.dirname(d)
 
-    def get_licenses(self, name, implicit=True):
+    def get_licenses(self, pkg_name, implicit=True):
         """
         @summary: Return a list of licenses and the packages in the dependency tree
             for the given package.
+        @param pkg_name: Name of the package the dependency tree begins from.
         @return Dictionary of license name and a list of packages.
         @rtype { k, [d] }
         @raise ResourceNotFound
@@ -400,17 +401,17 @@ class RosPack(ManifestManager):
         MSG_LICENSE_NOTFOUND_SYSPKG = "(License not automatically detected)"
         license_dict = defaultdict(list)
 
-        self.get_depends(name, implicit)
+        self.get_depends(name=pkg_name, implicit=implicit)
 
         manifests = self._manifests
 
-        for pkg_name, manifest in manifests.items():
+        for p_name, manifest in manifests.items():
             for license in manifest.licenses:
-                license_dict[license].append(pkg_name)
+                license_dict[license].append(p_name)
 
         # Traverse for Non-ROS, system packages
         try:
-            pkgnames_rosdep = self.get_rosdeps(name, implicit)
+            pkgnames_rosdep = self.get_rosdeps(name=pkg_name, implicit=implicit)
         except ResourceNotFound as e:
             raise e
         for pkgname_rosdep in pkgnames_rosdep:

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -391,8 +391,9 @@ class RosPack(ManifestManager):
 
     def get_licenses(self, name, implicit=True, sort_by_license=True):
         """
-        @summary: Return a list of licenses the packages the given package declares
-                             dependency on.
+        @summary: Return a list of licenses and the packages in the dependency tree
+            for the given package. Format of the returned object can vary depending on
+            the argument.
         @return Dictionary. By default dict of license name and a list of packages.
             When sort_by_license=False, dict of package name and a list of licenses.
         @rtype { k, [d] }

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -393,11 +393,8 @@ class RosPack(ManifestManager):
         """
         @summary: Return a list of licenses the packages the given package declares
                              dependency on.
-        @return Dictionary. By default dict of license name and package name(s).
-                       Note: For the packages that declare multiple licenses, those licenses
-                       are returned in a single string with each license separated by comma.
-                       E.g. if your package declares BSD and LGPL in separate tags in
-                       package.xml, the returned key will look like "BSD, LGPL".
+        @return Dictionary. By default dict of license name and a list of packages.
+            When sort_by_license=False, dict of package name and a list of licenses.
         @rtype { k, [d] }
         @raise ResourceNotFound
         """
@@ -410,9 +407,10 @@ class RosPack(ManifestManager):
 
         for pkg_name, manifest in manifests.items():
             if not sort_by_license:
-                license_dict[pkg_name].append(manifest.license)
+                license_dict[pkg_name].append(manifest.licenses)
             else:
-                license_dict[manifest.license].append(pkg_name)
+                for license in manifest.licenses:
+                    license_dict[license].append(pkg_name)
 
         # Traverse for Non-ROS, system packages
         try:

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -389,13 +389,11 @@ class RosPack(ManifestManager):
             else:
                 d = os.path.dirname(d)
 
-    def get_licenses(self, name, implicit=True, sort_by_license=True):
+    def get_licenses(self, name, implicit=True):
         """
         @summary: Return a list of licenses and the packages in the dependency tree
-            for the given package. Format of the returned object can vary depending on
-            the argument.
-        @return Dictionary. By default dict of license name and a list of packages.
-            When sort_by_license=False, dict of package name and a list of licenses.
+            for the given package.
+        @return Dictionary of license name and a list of packages.
         @rtype { k, [d] }
         @raise ResourceNotFound
         """
@@ -407,11 +405,8 @@ class RosPack(ManifestManager):
         manifests = self._manifests
 
         for pkg_name, manifest in manifests.items():
-            if not sort_by_license:
-                license_dict[pkg_name].append(manifest.licenses)
-            else:
-                for license in manifest.licenses:
-                    license_dict[license].append(pkg_name)
+            for license in manifest.licenses:
+                license_dict[license].append(pkg_name)
 
         # Traverse for Non-ROS, system packages
         try:
@@ -419,10 +414,7 @@ class RosPack(ManifestManager):
         except ResourceNotFound as e:
             raise e
         for pkgname_rosdep in pkgnames_rosdep:
-            if not sort_by_license:
-                license_dict[pkgname_rosdep].append(MSG_LICENSE_NOTFOUND_SYSPKG)
-            else:
-                license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
+            license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 
         # Sort pkg names in each license
         for list_key in license_dict.values():

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -407,22 +407,16 @@ class RosPack(ManifestManager):
                 license_dict[license].append(p_name)
 
         # Traverse for Non-ROS, system packages
-        pkgnames_rosdep = self.get_rosdeps(name=pkg_name, implicit=implicit)
+        pkgnames_rosdep = self.get_rosdeps(package=pkg_name, implicit=implicit)
         for pkgname_rosdep in pkgnames_rosdep:
             license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 
         # Sort pkg names in each license
         for list_key in license_dict.values():
             list_key.sort()
-        # Sort by license name.
+        # Sort license names
         licenses = OrderedDict(sorted(license_dict.items()))
-
-        # List of tuples converted into yaml can look like the following, which isn't 
-        # that useful. So here converting to a dict.
-        # - !!python/tuple
-        #  - LGPL
-        #   - - python_orocos_kdl
-        #     - orocos_kdl
+        # Convert to dict for user friendlier output.
         return dict(licenses)
 
 

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -389,7 +389,7 @@ class RosPack(ManifestManager):
             else:
                 d = os.path.dirname(d)
 
-    def get_licenses(self, name, implicit=True, sortbylicense=True):
+    def get_licenses(self, name, implicit=True, sort_by_license=True):
         """
         @summary: Return a list of licenses the packages the given package declares
                              dependency on.
@@ -409,7 +409,7 @@ class RosPack(ManifestManager):
         manifests = self._manifests
 
         for pkg_name, manifest in manifests.items():
-            if not sortbylicense:
+            if not sort_by_license:
                 license_dict[pkg_name].append(manifest.license)
             else:
                 license_dict[manifest.license].append(pkg_name)
@@ -420,7 +420,7 @@ class RosPack(ManifestManager):
         except ResourceNotFound as e:
             raise e
         for pkgname_rosdep in pkgnames_rosdep:
-            if not sortbylicense:
+            if not sort_by_license:
                 license_dict[pkgname_rosdep].append(MSG_LICENSE_NOTFOUND_SYSPKG)
             else:
                 license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -34,7 +34,6 @@ from collections import defaultdict, OrderedDict
 import os
 from threading import Lock
 from xml.etree.cElementTree import ElementTree
-import yaml
 
 from .common import MANIFEST_FILE, PACKAGE_FILE, ResourceNotFound, STACK_FILE
 from .environment import get_ros_paths
@@ -403,17 +402,12 @@ class RosPack(ManifestManager):
 
         self.get_depends(name=pkg_name, implicit=implicit)
 
-        manifests = self._manifests
-
-        for p_name, manifest in manifests.items():
+        for p_name, manifest in self._manifests.items():
             for license in manifest.licenses:
                 license_dict[license].append(p_name)
 
         # Traverse for Non-ROS, system packages
-        try:
-            pkgnames_rosdep = self.get_rosdeps(name=pkg_name, implicit=implicit)
-        except ResourceNotFound as e:
-            raise e
+        pkgnames_rosdep = self.get_rosdeps(name=pkg_name, implicit=implicit)
         for pkgname_rosdep in pkgnames_rosdep:
             license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -391,13 +391,14 @@ class RosPack(ManifestManager):
     def get_licenses(self, pkg_name, implicit=True):
         """
         @summary: Return a list of licenses and the packages in the dependency tree
-            for the given package.
+            for the given package. Special value 'ERR' is used as the license for the
+            packages that license was not detected for.
         @param pkg_name: Name of the package the dependency tree begins from.
         @return Dictionary of license name and a list of packages.
         @rtype { k, [d] }
         @raise ResourceNotFound
         """
-        MSG_LICENSE_NOTFOUND_SYSPKG = "(License not automatically detected)"
+        MSG_LICENSE_NOTFOUND_SYSPKG = "ERR"
         license_dict = defaultdict(list)
 
         self.get_depends(name=pkg_name, implicit=implicit)

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import os
 from threading import Lock
 from xml.etree.cElementTree import ElementTree
@@ -425,7 +425,18 @@ class RosPack(ManifestManager):
             else:
                 license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 
-        licenses = license_dict.items()
+        # Sort pkg names in each license
+        for list_key in license_dict.values():
+            list_key.sort()
+        # Sort by license name.
+        licenses = OrderedDict(sorted(license_dict.items()))
+
+        # List of tuples converted into yaml can look like the following, which isn't 
+        # that useful. So here converting to a dict.
+        # - !!python/tuple
+        #  - LGPL
+        #   - - python_orocos_kdl
+        #     - orocos_kdl
         return dict(licenses)
 
 

--- a/test/catkin_package_tests/p1/bar/package.xml
+++ b/test/catkin_package_tests/p1/bar/package.xml
@@ -8,14 +8,12 @@
   <maintainer email="someone@example.com">Someone</maintainer>
 
   <license>MIT</license>
-  <license>LGPL</license>
 
   <url type="website">http://wiki.ros.org/bar</url>
   <url type="bugtracker">http://www.github.com/my_org/bar/issues</url>
   <author>Jane Doe</author>
   <author email="jane.doe@example.com">Jane Doe</author>
 
-  <build_depend>catkin</build_depend>
   <depend>liburdfdom-dev</depend>
   <exec_depend>foo</exec_depend>
   <test_depend>gtest</test_depend>

--- a/test/catkin_package_tests/p1/bar/package.xml
+++ b/test/catkin_package_tests/p1/bar/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>bar</name>
+  <version>1.2.3</version>
+  <description>
+    I AM THE VERY MODEL OF A MODERN MAJOR GENERAL
+  </description>
+  <maintainer email="someone@example.com">Someone</maintainer>
+
+  <license>MIT</license>
+  <license>LGPL</license>
+
+  <url type="website">http://wiki.ros.org/bar</url>
+  <url type="bugtracker">http://www.github.com/my_org/bar/issues</url>
+  <author>Jane Doe</author>
+  <author email="jane.doe@example.com">Jane Doe</author>
+
+  <build_depend>catkin</build_depend>
+  <depend>liburdfdom-dev</depend>
+  <exec_depend>foo</exec_depend>
+  <test_depend>gtest</test_depend>
+  <export />
+</package>

--- a/test/catkin_package_tests/p1/foo/package.xml
+++ b/test/catkin_package_tests/p1/foo/package.xml
@@ -14,9 +14,6 @@
   <author>John Doe</author>
   <author email="jane.doe@example.com">Jane Doe</author>
 
-  <build_depend>catkin</build_depend>
-  <build_depend version_gte="1.1" version_lt="2.0">genmsg</build_depend>
-
   <build_depend>libboost-thread-dev</build_depend>
   <run_depend>libboost-thread</run_depend>
 

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -74,6 +74,7 @@ def test_get_licenses():
     search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
     manager = rospkg.rospack.RosPack(ros_paths=[search_path])
     licenses = manager.get_licenses("foo", implicit=False)
-    # package foo declares these 2 licenses in separate tags, which the dict
-    # get_licenses returns contains as a single string.
-    assert("BSD, LGPL" in licenses)
+    # package foo declares these 2 licenses.
+    assert not "BSD, LGPL" in licenses
+    assert("BSD" in licenses)
+    assert("LGPL" in licenses)

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -40,17 +40,18 @@ search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_pa
 
 
 def test_find_packages():
+    PKGS_EXIST = ['foo', 'bar']
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     # for backward compatibility a wet package which is not a metapackage is found when searching for MANIFEST_FILE
-    assert(len(manager.list()) == 1)
+    assert(len(manager.list()) == 2)
     manager = rospkg.rospack.ManifestManager(rospkg.common.STACK_FILE, ros_paths=[search_path])
     assert(len(manager.list()) == 0)
     manager = rospkg.rospack.ManifestManager(rospkg.common.PACKAGE_FILE, ros_paths=[search_path])
 
     for pkg_name in manager.list():
-        assert(pkg_name == 'foo')
+        assert(pkg_name in PKGS_EXIST)
         path = manager.get_path(pkg_name)
-        assert(path == os.path.join(search_path, 'p1', 'foo'))
+        assert(path == os.path.join(search_path, 'p1', PKGS_EXIST[PKGS_EXIST.index(pkg_name)]))
 
 
 def test_get_manifest():
@@ -70,10 +71,9 @@ def test_licenses():
 
 
 def test_get_licenses():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
-    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
-    licenses = manager.get_licenses("foo", implicit=False)
-    # package foo declares these 2 licenses.
-    assert not "BSD, LGPL" in licenses
+    """Check licenses from all packages in the dependency chain"""
+    rospack = rospkg.rospack.RosPack(ros_paths=[search_path])
+    licenses = rospack.get_licenses("bar", implicit=True)
+    assert("MIT" in licenses)
     assert("BSD" in licenses)
     assert("LGPL" in licenses)

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -59,7 +59,6 @@ def test_get_manifest():
     assert(manif.type == "package")
 
 
-
 def test_licenses():
     rospack = rospkg.rospack.RosPack(ros_paths=[search_path])
     licenses_list = ["BSD", "LGPL"]

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -59,6 +59,7 @@ def test_get_manifest():
     assert(manif.type == "package")
 
 
+
 def test_licenses():
     rospack = rospkg.rospack.RosPack(ros_paths=[search_path])
     licenses_list = ["BSD", "LGPL"]
@@ -67,3 +68,12 @@ def test_licenses():
     assert(len(manif.licenses) == 2)
     for l in manif.licenses:
         assert(l in licenses_list)
+
+
+def test_get_licenses():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    licenses = manager.get_licenses("foo", implicit=False)
+    # package foo declares these 2 licenses in separate tags, which the dict
+    # get_licenses returns contains as a single string.
+    assert("BSD, LGPL" in licenses)


### PR DESCRIPTION
```
$ ipython
In [1]: from rospkg import RosPack
In [2]: rp = RosPack()
In [3]: rp.get_licenses('roscpp')
Out[3]: defaultdict(<type 'list'>, {'BSD': ['rosconsole', 'catkin', 'cmake_modules', 'rospack', 'rosbuild', 'gencpp', 'roslib', 'geneus', 'roscpp_serialization', 'roscpp_traits', 'message_generation', 'roslang', 'genlisp', 'genpy', 'std_msgs', 'message_runtime', 'rostime', 'rosunit', 'rosgraph_msgs', 'genmsg', 'cpp_common'], 'LGPL-2.1': ['xmlrpcpp'], 'Apache 2.0': ['gennodejs']})
```

# Dependency on other PRs/Issues
- Depends on https://github.com/ros-infrastructure/rospkg/pull/164

# Review item list
- [x] Test cases if adding new functionality/feature.
- [x] Would be great if we can tell at a glance that the dependency is an immediate build depend (e.g. that's critical when it comes to L-GPL). -> Delegated to #132 
- [x] CI passing.
- [x] Provide how to run.
- [ ] Code review.