### PR TITLE
catkin-pkg missing from dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ kwargs = {
     'packages': ['rospkg'],
     'package_dir': {'': 'src'},
     'scripts': ['scripts/rosversion'],
-    'install_requires': ['PyYAML'],
+    'install_requires': ['catkin_pkg', 'PyYAML'],
     'author': 'Ken Conley',
     'author_email': 'kwc@willowgarage.com',
     'url': 'http://wiki.ros.org/rospkg',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,7 +1,7 @@
 [rospkg]
 Debian-Version: 100
-Depends: python-rospkg-modules
-Depends3: python3-rospkg-modules
+Depends: python-catkin-pkg, python-rospkg-modules
+Depends3: python3-catkin-pkg, python3-rospkg-modules
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -51,3 +51,10 @@ def test_find_packages():
         assert(pkg_name == 'foo')
         path = manager.get_path(pkg_name)
         assert(path == os.path.join(search_path, 'p1', 'foo'))
+
+
+def test_get_manifest():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
+    manif = manager.get_manifest("foo")
+    assert(manif.type == "package")


### PR DESCRIPTION
**ISSUE**

`catkin_pkg` is depended from [manifest.py](https://github.com/ros-infrastructure/rospkg/blob/8bfc04ae7062f7e4e4046f0175f60d2930f37f7a/src/rospkg/manifest.py#L394) but the dependency on it might not be specified.

Looks like `catkin_pkg` is not depended on.
```
$ apt-cache depends python-rospkg 
python-rospkg
  Depends: python
  Depends: python
  Depends: python-yaml
  Depends: python-rospkg-modules
  Conflicts: python3-rospkg
$ apt-cache policy python-rospkg
python-rospkg:
  Installed: 1.1.4-100
  Candidate: 1.1.4-100
  Version table:
 *** 1.1.4-100 500
        500 http://packages.ros.org/ros/ubuntu xenial/main amd64 Packages
        500 http://packages.ros.org/ros/ubuntu xenial/main i386 Packages
        100 /var/lib/dpkg/status
     1.0.38-1 500
        500 http://us.archive.ubuntu.com/ubuntu xenial/universe amd64 Packages
        500 http://us.archive.ubuntu.com/ubuntu xenial/universe i386 Packages
```

I found that when Travis CI for https://github.com/ros-infrastructure/rospkg/pull/133 fails (e.g. [here](https://travis-ci.org/ros-infrastructure/rospkg/jobs/341168445#L1180)) saying:
```
  File "/home/travis/build/ros-infrastructure/rospkg/src/rospkg/rospack.py", line 228, in get_depends
    m = self.get_manifest(name)
  File "/home/travis/build/ros-infrastructure/rospkg/src/rospkg/rospack.py", line 168, in get_manifest
    return self._load_manifest(name)
  File "/home/travis/build/ros-infrastructure/rospkg/src/rospkg/rospack.py", line 212, in _load_manifest
    retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
  File "/home/travis/build/ros-infrastructure/rospkg/src/rospkg/manifest.py", line 394, in parse_manifest_file
    from catkin_pkg.package import parse_package
ImportError: No module named catkin_pkg.package
```

Btw, purging `python-catkin-pkg` somehow purges `python-rospkg`.
```
$ sudo apt-get purge python-catkin-pkg
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  freeglut3-dev gazebo7 gazebo7-common gazebo7-plugin-base libapr1-dev libaprutil1-dev libbullet-dev
:
  python-pyside2.qtx11extras python-pyside2.qtxml python-rosdistro python-rospkg python-sip-dev
:
Use 'sudo apt autoremove' to remove them.
```

**Solution**

I don't know the right way to fix this issue though
(Curious to see if Travis CI will install the missing dependency by this change).