### PR TITLE
add buster for debian 10 (anticipated version number)

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -160,6 +160,8 @@ class Debian(LsbDetect):
                 return 'jessie'
             if v.startswith('9.'):
                 return 'stretch'
+            if v.startswith('10.'):
+                return 'buster'
             return ''
 
 


### PR DESCRIPTION
addresses https://github.com/ros-infrastructure/rospkg/issues/125#issuecomment-361775880 but cannot be tested as debian buster still uses "buster/sid" as the version number