### PR TITLE
os_detect: add support for Alpine

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -668,7 +668,7 @@ class OsDetect:
             self.detect_os()
         return self._os_codename
 
-
+OS_ALPINE = 'alpine'
 OS_ARCH = 'arch'
 OS_MANJARO = 'manjaro'
 OS_CENTOS = 'centos'
@@ -693,6 +693,7 @@ OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
 OS_WINDOWS = 'windows'
 
+OsDetect.register_default(OS_ALPINE, FdoDetect("Alpine Linux"))
 OsDetect.register_default(OS_ARCH, Arch())
 OsDetect.register_default(OS_MANJARO, Manjaro())
 OsDetect.register_default(OS_CENTOS, Centos())

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -668,6 +668,7 @@ class OsDetect:
             self.detect_os()
         return self._os_codename
 
+
 OS_ALPINE = 'alpine'
 OS_ARCH = 'arch'
 OS_MANJARO = 'manjaro'


### PR DESCRIPTION
Add support for alpine.
In `/etc/os-release`:

```
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.7.0
PRETTY_NAME="Alpine Linux v3.7"
HOME_URL="http://alpinelinux.org"
BUG_REPORT_URL="http://bugs.alpinelinux.org"
```

Tested in a container running `rosdep init && rosdep update`.