### PR TITLE
Python3 fix for manifest decoding

### DIFF
--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -430,8 +430,8 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
 
         return manifest
 
-    with open(filename, 'r') as f:
-        return parse_manifest(manifest_name, f.read(), filename)
+    with open(filename, 'rb') as f:
+        return parse_manifest(manifest_name, f.read().decode('utf-8'), filename)
 
 
 def parse_manifest(manifest_name, string, filename='string'):


### PR DESCRIPTION
Doing the same kind of fixes which happened in the other ROS packages.

Without it I am getting
```
File "/usr/local/lib/python3.6/dist-packages/rospkg/manifest.py", line 434, in parse_manifest_file
    return parse_manifest(manifest_name, f.read(), filename)
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 213: ordinal not in range(128)
```