### PR TITLE
Fix inconsistent return value of get_rosdeps

### DIFF
--- a/src/rospkg/common.py
+++ b/src/rospkg/common.py
@@ -45,9 +45,21 @@ class ResourceNotFound(Exception):
     A ROS filesystem resource was not found.
     """
 
-    def __init__(self, msg, ros_paths=None):
+    def __init__(self, msg, ros_paths=None, deps_sofar=None, deps_unavailable=None):
+        """
+        :type deps_sofar: [str]
+        :param deps_sofar: List of depended packages at the time the command
+                                        stopped due to this exception.
+        :type deps_unavailable: [str]
+        :param deps_unavailable: List of packages defined in the dependency but are not
+                                                  available on the platform.
+        """
         super(ResourceNotFound, self).__init__(msg)
         self.ros_paths = ros_paths
+        self.deps_sofar = deps_sofar
+        self.deps_unavailable = set()
+        if deps_unavailable:
+            self.deps_unavailable.update(deps_unavailable)
 
     def __str__(self):
         s = self.args[0]  # python 2.6
@@ -55,3 +67,6 @@ class ResourceNotFound(Exception):
             for i, p in enumerate(self.ros_paths):
                 s = s + '\nROS path [%s]=%s' % (i, p)
         return s
+
+    def get_depends(self):
+        return self.deps_sofar

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -362,9 +362,18 @@ class RosPack(ManifestManager):
         self._rosdeps_cache[package] = s = set()
 
         # take the union of all dependencies
-        packages = self.get_depends(package, implicit=True)
-        for p in packages:
-            s.update(self.get_rosdeps(p, implicit=False))
+        packages = []
+        try:
+            packages = self.get_depends(package, implicit=True)
+        except ResourceNotFound as e:
+            del self._rosdeps_cache[package]
+            packages = e.get_depends()
+        if packages:
+            for p in packages:
+                try:
+                    s.update(self.get_rosdeps(p, implicit=False))
+                except ResourceNotFound as e:
+                    print("Not available in your environment: {}".format(str(e)))
         # add in our own deps
         m = self.get_manifest(package)
         s.update([d.name for d in m.rosdeps])

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -58,3 +58,27 @@ def test_get_manifest():
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
+
+
+def test_get_rosdeps_rsc_nonexistent():
+    """
+    @summary: get_rosdeps needs to raise rospkg.ResourceNotFound every time
+                          a non-existent package is passed.
+    """
+    search_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    # Need to run get_rosdeps twice and both must raise the same exception.
+    # https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083
+    try:  # 1st run
+        manager.get_rosdeps("pkg_nonexistent")
+    except rospkg.ResourceNotFound as e:
+        pass
+
+    try:  # 2nd run
+        manager.get_rosdeps("pkg_nonexistent")
+    except rospkg.ResourceNotFound as e:
+        pass
+    else:
+        print("ResourceNotFound expected but wasn't raised. Failure.")
+        assert(False)


### PR DESCRIPTION
Opening a separate PR for a part of the issues discussed in https://github.com/ros-infrastructure/rospkg/pull/129.

**Issue**

When either the passed package, or packages in the dependency chaing are not available on the `ROS_PACKAGE_PATH` environment, the following problems can occur for `RosPack.get_rosdeps`:
- On the 1st invocation `ResourceNotFound` is raised (which I think is correct behavior). But on 2nd invocation, an empty set (`set()`) is returned when there is more than one package is unavailable in your environment.

**Expected output**

`ResourceNotFound` being raised on every invocation as long as the package availability is the same.

**Problem behavior output**

```
$ docker images | grep -i melodic
ros                                                                melodic                                     8141688e8439        4 days ago          1.2GB
$ docker run -it ros:melodic

root@229f8e380d55:/# apt-cache policy python-rospkg
python-rospkg:
  Installed: 1.1.4-100
  Candidate: 1.1.4-100

$ ipython
```
Case-A. Passed package exists but some pkgs in the dependency are missing.
```
In [1]: import rospkg
In [2]: rp = rospkg.RosPack()
In [3]: rp.get_rosdeps("roscpp")
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-d0c5947c660f> in <module>()
----> 1 rp.get_rosdeps("roscpp")

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_rosdeps(self, package, implicit)
    343         """
    344         if implicit:
--> 345             return self._implicit_rosdeps(package)
    346         else:
    347             m = self.get_manifest(package)

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in _implicit_rosdeps(self, package)
    363 
    364         # take the union of all dependencies
--> 365         packages = self.get_depends(package, implicit=True)
    366         for p in packages:
    367             s.update(self.get_rosdeps(p, implicit=False))

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    238 
    239             for p in names:
--> 240                 s.update(self.get_depends(p, implicit))
    241             # add in our own deps
    242             s.update(names)

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    232 
    233             # take the union of all dependencies
--> 234             names = [p.name for p in self.get_manifest(name).depends]
    235 
    236             # assign key before recursive call to prevent infinite case

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_manifest(self, name)
    165             return self._manifests[name]
    166         else:
--> 167             return self._load_manifest(name)
    168 
    169     def _update_location_cache(self):

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in _load_manifest(self, name)
    209         :raises: :exc:`ResourceNotFound`
    210         """
--> 211         retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
    212         return retval
    213 

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_path(self, name)
    201         self._update_location_cache()
    202         if name not in self._location_cache:
--> 203             raise ResourceNotFound(name, ros_paths=self._ros_paths)
    204         else:
    205             return self._location_cache[name]

ResourceNotFound: roslang
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/opt/ros/kinetic/share

In [4]: rp.get_rosdeps("roscpp")
Out[4]: set()
```
Case-B. Passing non-existent pkg ends up being the same error.
```
In [5]: import rospkg
   ...: rp = rospkg.RosPack()
   ...: rp.get_rosdeps("tempura")
   ...: 
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-6b34bdbd7341> in <module>()
      1 import rospkg
      2 rp = rospkg.RosPack()
----> 3 rp.get_rosdeps("tempura")

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_rosdeps(self, package, implicit)
    343         """
    344         if implicit:
--> 345             return self._implicit_rosdeps(package)
    346         else:
    347             m = self.get_manifest(package)

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in _implicit_rosdeps(self, package)
    363 
    364         # take the union of all dependencies
--> 365         packages = self.get_depends(package, implicit=True)
    366         for p in packages:
    367             s.update(self.get_rosdeps(p, implicit=False))

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_depends(self, name, implicit)
    232 
    233             # take the union of all dependencies
--> 234             names = [p.name for p in self.get_manifest(name).depends]
    235 
    236             # assign key before recursive call to prevent infinite case

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_manifest(self, name)
    165             return self._manifests[name]
    166         else:
--> 167             return self._load_manifest(name)
    168 
    169     def _update_location_cache(self):

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in _load_manifest(self, name)
    209         :raises: :exc:`ResourceNotFound`
    210         """
--> 211         retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
    212         return retval
    213 

/usr/lib/python2.7/dist-packages/rospkg/rospack.pyc in get_path(self, name)
    201         self._update_location_cache()
    202         if name not in self._location_cache:
--> 203             raise ResourceNotFound(name, ros_paths=self._ros_paths)
    204         else:
    205             return self._location_cache[name]

ResourceNotFound: tempura
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/opt/ros/melodic/share

In [6]: rp.get_rosdeps("tempura")
Out[6]: set()
```

**Output with the suggested change**

```
In [1]: import rospkg
   ...: rp = rospkg.RosPack()
   ...: rp.get_rosdeps("roscpp")
   ...: 
Out[1]: ['pkg-config']

In [2]: rp.get_rosdeps("roscpp")
Out[2]: ['pkg-config']


In [3]: rp.get_rosdeps("tempura")
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-f7d954fd9c03> in <module>()
----> 1 rp.get_rosdeps("tempura")

/tmp/rospkg/src/rospkg/rospack.py in get_rosdeps(self, package, implicit)
    343         """
    344         if implicit:
--> 345             return self._implicit_rosdeps(package)
    346         else:
    347             m = self.get_manifest(package)

/tmp/rospkg/src/rospkg/rospack.py in _implicit_rosdeps(self, package)
    376                     print("Not available in your environment: {}".format(str(e)))
    377         # add in our own deps
--> 378         m = self.get_manifest(package)
    379         s.update([d.name for d in m.rosdeps])
    380         # cache the return value as a list

/tmp/rospkg/src/rospkg/rospack.py in get_manifest(self, name)
    165             return self._manifests[name]
    166         else:
--> 167             return self._load_manifest(name)
    168 
    169     def _update_location_cache(self):

/tmp/rospkg/src/rospkg/rospack.py in _load_manifest(self, name)
    209         :raises: :exc:`ResourceNotFound`
    210         """
--> 211         retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
    212         return retval
    213 

/tmp/rospkg/src/rospkg/rospack.py in get_path(self, name)
    201         self._update_location_cache()
    202         if name not in self._location_cache:
--> 203             raise ResourceNotFound(name, ros_paths=self._ros_paths)
    204         else:
    205             return self._location_cache[name]

ResourceNotFound: tempura
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/opt/ros/melodic/share

In [4]: rp.get_rosdeps("tempura")
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-4-f7d954fd9c03> in <module>()
----> 1 rp.get_rosdeps("tempura")

/tmp/rospkg/src/rospkg/rospack.py in get_rosdeps(self, package, implicit)
    343         """
    344         if implicit:
--> 345             return self._implicit_rosdeps(package)
    346         else:
    347             m = self.get_manifest(package)

/tmp/rospkg/src/rospkg/rospack.py in _implicit_rosdeps(self, package)
    376                     print("Not available in your environment: {}".format(str(e)))
    377         # add in our own deps
--> 378         m = self.get_manifest(package)
    379         s.update([d.name for d in m.rosdeps])
    380         # cache the return value as a list

/tmp/rospkg/src/rospkg/rospack.py in get_manifest(self, name)
    165             return self._manifests[name]
    166         else:
--> 167             return self._load_manifest(name)
    168 
    169     def _update_location_cache(self):

/tmp/rospkg/src/rospkg/rospack.py in _load_manifest(self, name)
    209         :raises: :exc:`ResourceNotFound`
    210         """
--> 211         retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
    212         return retval
    213 

/tmp/rospkg/src/rospkg/rospack.py in get_path(self, name)
    201         self._update_location_cache()
    202         if name not in self._location_cache:
--> 203             raise ResourceNotFound(name, ros_paths=self._ros_paths)
    204         else:
    205             return self._location_cache[name]

ResourceNotFound: tempura
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/opt/ros/melodic/share
```

- Note that with `roscpp` passed, only 1 pkg is returned, which fell short of what's supposed to be returned. This is because of an issue in `get_depends` that `get_rosdeps` depends on (as mentioned in https://github.com/ros-infrastructure/rospkg/pull/129#issuecomment-364572565). I have another PR to open for that.
- Responding to suggestion https://github.com/ros-infrastructure/rospkg/pull/129#issuecomment-365998688, I added a testcase https://github.com/130s/rospkg/commit/9e0b8e3cf5ad300f8877f183eac13474e70b16d1. You can see it failing [on CI](https://travis-ci.org/130s/rospkg/builds/384954223). Note that for clarity I created a separate branch that just has that commit, but the same commit is included in this PR.
