### PR TITLE
WIP: Add license introspection feature. This handles Ubuntu system pkg

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -34,6 +34,7 @@ tools.
    rospkg_environment
    os_detect
    rospkg_distro
+   sw_license_introspection
    
 Example::
 

--- a/doc/sw_license_introspection.rst
+++ b/doc/sw_license_introspection.rst
@@ -1,0 +1,183 @@
+Software license introspection
+=======================
+
+.. module:: rospkg.sw_license
+    :synopsis: Software license introspection for ROS and system packages.
+
+The :mod:`rospkg.sw_license` module provides a feature to list up software
+license for all ROS packages in the dependency chain. It also provides some utilities
+regarding software license.
+
+Commandline tools
+-----------------
+
+Command line script ``sw_licenses`` provides a single point of entry for APIs regarding software license.
+
+Introspect software license for a given package and packages it depends on
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Syntax::
+
+    sw_licenses %PKG_NAME%
+
+Example::
+
+    sw_licenses rviz
+    :
+    Path of the output file: /tmp/licenses_rviz-1.11.18.yml
+
+    cat /tmp/licenses_rviz-1.11.18.yml
+    :
+    BSD:
+    - rosconsole
+    - rosparam
+    - catkin
+    :
+    BSD, Creative Commons:
+    - rviz
+    unknown:
+    - python-rospkg
+    - python-catkin-pkg
+    - python-rosdep
+
+
+
+.. autoclass:: OsNotDetected
+
+.. class:: OsDetect(os_list)
+
+   Detects the current operating system.  This class will iterate
+   over registered classes to lookup the active OS and version.  The
+   list of detectors can be overridden in the constructor; otherwise
+   it will default to :class:`OsDetector` classes provided by this
+   library.
+
+
+    .. attribute:: default_os_list
+
+        List of currently registered detectors.  Must not be modified directly.
+    
+    .. staticmethod:: register_default(os_name, os_detector)
+
+        Register detector to be used with all future instances of
+        :class:`OsDetect`.  The new detector will have precedence over
+        any previously registered detectors associated with *os_name*.
+        
+    .. method:: detect_os() -> tuple
+
+        :returns: (os_name, os_version, os_codename), ``(str, str, str)``
+        :raises: :exc:`OsNotDetected` if OS could not be detected
+
+    .. method:: get_detector([name]) -> OsDetector
+
+        Get detector used for specified OS name, or the detector for this OS if name is ``None``.
+
+        :raises: :exc:`KeyError`
+        
+    .. method:: add_detector(name, detector)
+
+        Add detector to list of detectors used by this instance.
+        *detector* will override any previous detectors associated
+        with *name*.
+
+        :param name: OS name that detector matches
+        :param detector: :class:`OsDetector` instance
+
+    .. method:: get_os() -> OsDetector
+
+        Get :class:`OsDetector` for this operating system.
+        
+        :raises: :exc:`OsNotDetected` if OS could not be detected
+
+    .. method:: get_name() -> str
+
+        :returns: Name of current operating system.  See ``OS_*``
+          definitions in this module for possible values.
+        :raises: :exc:`OsNotDetected` if OS could not be detected
+
+    .. method:: get_version() -> str
+
+        :returns: Version of current operating system
+        :raises: :exc:`OsNotDetected` if OS could not be detected
+
+    .. method:: get_codename() -> str
+
+        :returns: Codename of current operating system if available,
+          or empty string if OS does not provide codename.
+        :raises: :exc:`OsNotDetected` if OS could not be detected
+
+
+
+.. autoclass:: OsDetector
+   :members:
+
+
+
+OS name definitions
+-------------------
+
+.. data:: OS_ARCH
+
+   Name used for Arch Linux OS.
+
+.. data:: OS_CYGWIN
+
+   Name used for Cygwin OS.
+
+.. data:: OS_DEBIAN
+
+   Name used for Debian OS.
+
+.. data:: OS_FREEBSD
+
+   Name used for FreeBSD OS.
+
+.. data:: OS_GENTOO
+
+   Name used for Gentoo.
+
+.. data:: OS_MINT
+
+   Name used for Mint OS.
+
+.. data:: OS_OPENSUSE
+
+   Name used for OpenSUSE OS.
+
+.. data:: OS_OSX
+
+   Name used for OS X.
+
+.. data:: OS_RHEL
+
+   Name used for Red Hat Enterprise Linux.
+
+.. data:: OS_SLACKWARE
+
+   Name used for Slackware.
+
+.. data:: OS_UBUNTU
+
+   Name used for Ubuntu OS.
+
+
+Linux helper methods
+--------------------
+
+.. method:: lsb_get_os() -> str
+
+    Linux: wrapper around lsb_release to get the current OS
+    
+.. method:: lsb_get_codename() -> str
+
+    Linux: wrapper around lsb_release to get the current OS codename
+    
+.. method:: lsb_get_version() -> str
+
+    Linux: wrapper around lsb_release to get the current OS version
+
+.. method:: uname_get_machine() -> str
+
+    Linux: wrapper around uname to determine if OS is 64-bit
+
+

--- a/scripts/sw_licenses
+++ b/scripts/sw_licenses
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Copyright 2018 PlusOne Robotics Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the PlusOne Robotics Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import argparse
+import logging
+import sys
+
+from rospkg.sw_license import  LicenseUtil
+
+PATH_PREFIX_OUTPUT = "/tmp/licenses"
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=
+                                     'List the OSS licenses of all ROS dependency for the given package.')
+    parser.add_argument(
+        'pkg_name', help='Package that starts tracking from to get the all licenses of.')
+    parser.add_argument(
+        '--path_licenses_prev',
+        help="Path of a file to be compared from. Run comparison if this is passed.")
+    parser.add_argument(
+        '--prefix_outfile', help='Prefix of the output file in an absolute path.'
+        ' By default it is {}'.format(PATH_PREFIX_OUTPUT),
+        default="{}".format(PATH_PREFIX_OUTPUT))
+    args = parser.parse_args()
+    license_util = LicenseUtil()
+    dict_licenses = license_util.software_license(args.pkg_name)
+    licenses, path_licenses = license_util.save_licenses(
+        dict_licenses, args.pkg_name, prefix_outfile=args.prefix_outfile)
+    print("Path of the output file: {}".format(path_licenses))
+    if args.path_licenses_prev:
+        ret = license_util.compare_license(args.path_licenses_prev, path_licenses)
+        if not ret:
+            logging.error("New license found. Exiting with 1.")
+            sys.exit(1)

--- a/scripts/sw_licenses
+++ b/scripts/sw_licenses
@@ -31,7 +31,7 @@ import argparse
 import logging
 import sys
 
-from rospkg.sw_license import  LicenseUtil
+from rospkg.sw_license import LicenseUtil, SwLicenseException
 
 PATH_PREFIX_OUTPUT = "/tmp/licenses"
 
@@ -51,11 +51,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
     license_util = LicenseUtil()
     dict_licenses = license_util.software_license(args.pkg_names)
-    licenses, path_licenses = license_util.save_licenses(
+    path_licenses = license_util.save_licenses(
         dict_licenses, args.pkg_names, prefix_outfile=args.prefix_outfile)
     print("Path of the output file: {}".format(path_licenses))
     if args.path_licenses_prev:
-        ret = license_util.compare_license(args.path_licenses_prev, path_licenses)
-        if not ret:
-            logging.error("New license found. Exiting with 1.")
+        try:
+            license_util.compare_license(args.path_licenses_prev, path_licenses)
+        except SwLicenseException as e:
+            logging.error(str(e))
             sys.exit(1)

--- a/scripts/sw_licenses
+++ b/scripts/sw_licenses
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=
                                      'List the OSS licenses of all ROS dependency for the given package.')
     parser.add_argument(
-        'pkg_name', help='Package that starts tracking from to get the all licenses of.')
+        'pkg_names', help="Packages that start from to get the all licenses of. Delimit by comma and enclose the entire list by double quote when multiple packages passed. Result will be consolidated into one file.")
     parser.add_argument(
         '--path_licenses_prev',
         help="Path of a file to be compared from. Run comparison if this is passed.")
@@ -50,9 +50,9 @@ if __name__ == "__main__":
         default="{}".format(PATH_PREFIX_OUTPUT))
     args = parser.parse_args()
     license_util = LicenseUtil()
-    dict_licenses = license_util.software_license(args.pkg_name)
+    dict_licenses = license_util.software_license(args.pkg_names)
     licenses, path_licenses = license_util.save_licenses(
-        dict_licenses, args.pkg_name, prefix_outfile=args.prefix_outfile)
+        dict_licenses, args.pkg_names, prefix_outfile=args.prefix_outfile)
     print("Path of the output file: {}".format(path_licenses))
     if args.path_licenses_prev:
         ret = license_util.compare_license(args.path_licenses_prev, path_licenses)

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -42,7 +42,7 @@ import xml.dom.minidom as dom
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE
 
 # stack.xml and manifest.xml have the same internal tags right now
-REQUIRED = ['license']
+REQUIRED = ['license', "name"]
 ALLOWXHTML = ['description']
 OPTIONAL = ['author', 'logo', 'url', 'brief', 'description', 'status',
             'notes', 'depend', 'rosdep', 'export', 'review',
@@ -318,7 +318,7 @@ class Manifest(object):
         'author', 'license', 'license_url', 'url',
         'depends', 'rosdeps', 'platforms',
         'exports', 'version',
-        'status', 'notes',
+        'status', 'name', 'notes',
         'unknown_tags', 'type', 'filename',
         'is_catkin']
 
@@ -331,7 +331,7 @@ class Manifest(object):
         self.description = self.brief = self.author = \
             self.license = self.license_url = \
             self.url = self.status = \
-            self.version = self.notes = ''
+            self.version = self.notes = self.name = ''
         self.depends = []
         self.rosdeps = []
         self.exports = []
@@ -395,6 +395,7 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
         p = parse_package(package_filename)
         # put these into manifest
         manifest.description = p.description
+        manifest.name = p.name
         manifest.author = ', '.join([('Maintainer: %s' % str(m)) for m in p.maintainers] + [str(a) for a in p.authors])
         manifest.license = ', '.join(p.licenses)
         if p.urls:
@@ -497,6 +498,7 @@ def parse_manifest(manifest_name, string, filename='string'):
         pass  # manifest is missing optional 'review notes' tag
 
     m.author = _check('author', True)(p, filename)
+    m.name = _check("name")(p, filename)
     m.url = _check('url')(p, filename)
     m.version = _check('version')(p, filename)
 

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import os
 from threading import Lock
 from xml.etree.cElementTree import ElementTree
@@ -425,7 +425,18 @@ class RosPack(ManifestManager):
             else:
                 license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 
-        licenses = license_dict.items()
+        # Sort pkg names in each license
+        for list_key in license_dict.values():
+            list_key.sort()
+        # Sort by license name.
+        licenses = OrderedDict(sorted(license_dict.items()))
+
+        # List of tuples converted into yaml can look like the following, which isn't 
+        # that useful. So here converting to a dict.
+        # - !!python/tuple
+        #  - LGPL
+        #   - - python_orocos_kdl
+        #     - orocos_kdl
         return dict(licenses)
 
 

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -31,13 +31,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 import logging
-from rospkg import ResourceNotFound, RosPack
 import yaml
+
+from rospkg import ResourceNotFound, RosPack
 
 
 class LicenseUtil(object):
+    _URL_ISSUE_RELEVANT = "https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
 
     def __init__(self):
         self.rp = RosPack()
@@ -69,26 +71,77 @@ class LicenseUtil(object):
                 logging.info("License '{}' was present.".format(key))
         return ret
 
-    def software_license(self, pkgname):
+    def software_license(self, pkgnames):
         """
-        @return List of licenses and packages.
+        @type pkgnames: Either one of the following:
+                    - [str]: list of str.
+                    - str str...str: space separated string.
+        @param pkgnames: Name of one or more packages to start software license
+                       introspection from (i.e. leaf packages in the dependency chain).
+        @return List of software licenses found in the dependency chain started from
+                       the package names passed in 'pkgnames'. When multiple packages
+                       passed to start with, union of all the results is returned.
         @raise AttributeError, ResourceNotFound
         """
-        if not pkgname:
-            raise ValueError("Argument was insufficient: pkgname {}".format(pkgname))
-        try:
-            dict_license = self.rp.get_licenses(pkgname)
-        except AttributeError as e:
-            raise e
-        except ResourceNotFound as e:
-            URL_ISSUE_RELEVANT="https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
-            logging.warn("{}\nRe-run get_licenses to work around an issue with get_depends (see {} if needed).".format(repr(e), URL_ISSUE_RELEVANT))
-            dict_license = self.rp.get_licenses(pkgname)
-        logging.debug(dict_license)
-        return dict_license
+        if not pkgnames:
+            raise ValueError("Argument was insufficient: pkgname {}".format(pkgnames))
+
+        # Check if pkgnames is str, not list.
+        if isinstance(pkgnames, basestring):
+            # If space(s) are found, 1) take it as a single package name if only one str
+            # element is found. 2) Convert to [str] if multiple str elements found.
+            pkgnames = pkgnames.split()
+
+        # Could store multiple resulted dicts for a package
+        dicts_of_result = []
+        for pkg_name in pkgnames:
+            try:
+                dict_license = self.rp.get_licenses(pkg_name)
+            except AttributeError as e:
+                raise e
+            except ResourceNotFound as e:
+                logging.warn(
+                    "{}\nRe-running Rospack.get_licenses to work around an issue with"
+                    " get_depends (see {} if needed).".format(
+                        repr(e), self._URL_ISSUE_RELEVANT))
+                dict_license = self.rp.get_licenses(pkg_name)
+            dicts_of_result.append(dict_license)
+
+        # Take the union of the results.
+        dict_licenses = self._union_dicts(dicts_of_result)
+        logging.debug(dict_licenses)
+        return dict_licenses
+
+    def _union_dicts(self, d):
+        """
+        @param *d: dictionaries, each of which needs to be formatted as the output of
+                       rospkg.RosPack.get_licenses (otherwise), i.e. { k, [d] }.
+        @rtype { k, [d] }
+        """
+        # https://stackoverflow.com/a/14766978/577001
+
+        logging.debug("d: {} len(d): {}\n".format(d, len(d)))
+
+        newdicts = defaultdict(set)  # Define a defaultdict
+        for each_dict in d:
+            logging.debug("each_dict: {}\n".format(each_dict))
+            #ordered_dic = OrderedDict(sorted(list(each_dict)[0].items()))
+            ordered_dic = OrderedDict(sorted(each_dict.items()))
+
+            # dict.items() returns a list of (k, v) tuple.
+            # So, you can directly unpack the tuple in two loop variables.
+            for k, v in ordered_dic.items():
+                newdicts[k] |= set(v)
+
+            logging.debug("newdicts: {}\n".format(newdicts))
+        # And if you want the exact representation that you have shown
+        # You can build a normal dict out of your newly built dict.
+        union = {key: sorted(list(value)) for key, value in newdicts.items()}
+        logging.debug(union)
+        return union
 
     def save_licenses(
-            self, licenses, pkgname, implicit=True, sortbylicense=True,
+            self, licenses, pkgnames, implicit=True, sortbylicense=True,
             prefix_outfile="/tmp/licenses", description_output=None):
         """
         @summary:  If True save the result of get_licenses to a text file.
@@ -104,14 +157,25 @@ class LicenseUtil(object):
         @raise ResourceNotFound
         """
         pkg_version = "pkgversion"
-        if not description_output:
-            description_output = "# Output of software license introspection started from {}.".format(pkgname)
 
-        try:
-            pkg_version = self.rp.get_manifest(pkgname).version
-        except Exception as e:
-            print(str(e))
-        path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
+        if isinstance(pkgnames, basestring):
+            pkgnames = pkgnames.split()
+
+        if not description_output:
+            description_output = """# Output of software license introspection started from {}""".format(pkgnames)
+
+        pkgnames_versions = []
+        for pkgname in pkgnames:
+            try:
+                pkg_version = self.rp.get_manifest(pkgname).version
+                pkgnames_versions.append("{}-{}".format(pkgname, pkg_version))
+            except Exception as e:
+                print(str(e))
+
+        # Delimits package name with underscore.
+        pkgnames_versions_str = "_".join(pkgnames_versions)
+
+        path_outputfile = '{}-{}.yml'.format(prefix_outfile, pkgnames_versions_str)
         with open(path_outputfile, 'w') as outfile:
             outfile.write("{}\n".format(description_output))
             yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -88,7 +88,8 @@ class LicenseUtil(object):
         return dict_license
 
     def save_licenses(
-            self, licenses, pkgname, implicit=True, sortbylicense=True, prefix_outfile="/tmp/licenses",):
+            self, licenses, pkgname, implicit=True, sortbylicense=True,
+            prefix_outfile="/tmp/licenses", description_output=None):
         """
         @summary:  If True save the result of get_licenses to a text file.
         @param licenses: TBD
@@ -97,17 +98,22 @@ class LicenseUtil(object):
         @param prefix_outfile: Prefix of the output file in an absolute full path style.
                                               E.g. by default output of pkgA version 1.0.0 will be saved at:
                                                    /tmp/licenses_pkgA-1.0.0.log
+        @param description_output: Description printed at the top of the output file.
         @return 1) License object, 2) Path of the resulted file (either absolute/relative
                        depending on the prefix_outfile)
         @raise ResourceNotFound
         """
         pkg_version = "pkgversion"
+        if not description_output:
+            description_output = "# Output of software license introspection started from {}.".format(pkgname)
+
         try:
             pkg_version = self.rp.get_manifest(pkgname).version
         except Exception as e:
             print(str(e))
         path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
         with open(path_outputfile, 'w') as outfile:
-            yaml.dump(licenses, outfile, default_flow_style=False)
+            outfile.write("{}\n".format(description_output))
+            yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)
             logging.debug("Result saved at {}".format(path_outputfile))
         return licenses, path_outputfile

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -1,0 +1,113 @@
+# Copyright 2018 PlusOne Robotics Inc.
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, PlusOne Robotics, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of PlusOne Robotics, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from collections import OrderedDict
+import logging
+from rospkg import ResourceNotFound, RosPack
+import yaml
+
+
+class LicenseUtil(object):
+
+    def __init__(self):
+        self.rp = RosPack()
+
+    def compare_license(self, path_a="", path_b=""):
+        """
+        @summary Compare 2 files of license output and returns any new license entries.
+        """
+        ret = True
+        stream_a = open(path_a, "r")
+        yaml_a = yaml.load_all(stream_a)
+
+        stream_b = open(path_b, "r")
+        yaml_b = yaml.load_all(stream_b)
+
+        # PyYaml doesn't preserve order of input yaml, so this is needed.
+        # https://github.com/yaml/pyyaml/issues/110
+        ordered_a = OrderedDict(sorted(list(yaml_a)[0].items()))
+        ordered_b = OrderedDict(sorted(list(yaml_b)[0].items()))
+        logging.debug("yaml_a: {}\nyaml_b: {}".format(ordered_a, ordered_b))
+        # What to check?
+        # - Key addition
+        # - Values
+        for key in ordered_a:
+            if key not in ordered_b:
+                logging.error("License '{}' was NOT present in the input file.".format(key))
+                ret = False
+            else:
+                logging.info("License '{}' was present.".format(key))
+        return ret
+
+    def software_license(self, pkgname):
+        """
+        @return List of licenses and packages.
+        @raise AttributeError, ResourceNotFound
+        """
+        if not pkgname:
+            raise ValueError("Argument was insufficient: pkgname {}".format(pkgname))
+        try:
+            dict_license = self.rp.get_licenses(pkgname)
+        except AttributeError as e:
+            raise e
+        except ResourceNotFound as e:
+            URL_ISSUE_RELEVANT="https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
+            logging.warn("{}\nRe-run get_licenses to work around an issue with get_depends (see {} if needed).".format(repr(e), URL_ISSUE_RELEVANT))
+            dict_license = self.rp.get_licenses(pkgname)
+        logging.debug(dict_license)
+        return dict_license
+
+    def save_licenses(
+            self, licenses, pkgname, implicit=True, sortbylicense=True, prefix_outfile="/tmp/licenses",):
+        """
+        @summary:  If True save the result of get_licenses to a text file.
+        @param licenses: TBD
+        @param implicit: Same as the one in get_depends
+        @param sortbylicense: Same as the one in get_licenses
+        @param prefix_outfile: Prefix of the output file in an absolute full path style.
+                                              E.g. by default output of pkgA version 1.0.0 will be saved at:
+                                                   /tmp/licenses_pkgA-1.0.0.log
+        @return 1) License object, 2) Path of the resulted file (either absolute/relative
+                       depending on the prefix_outfile)
+        @raise ResourceNotFound
+        """
+        pkg_version = "pkgversion"
+        try:
+            pkg_version = self.rp.get_manifest(pkgname).version
+        except Exception as e:
+            print(str(e))
+        path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
+        with open(path_outputfile, 'w') as outfile:
+            yaml.dump(licenses, outfile, default_flow_style=False)
+            logging.debug("Result saved at {}".format(path_outputfile))
+        return licenses, path_outputfile

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -36,6 +36,8 @@ import logging
 import yaml
 
 from rospkg import ResourceNotFound, RosPack
+from rospkg.environment import get_ros_root
+from rospkg.os_detect import OsDetect
 
 
 class LicenseUtil(object):
@@ -43,6 +45,7 @@ class LicenseUtil(object):
 
     def __init__(self):
         self.rp = RosPack()
+        self._os_detect = OsDetect()
 
     def compare_license(self, path_a="", path_b=""):
         """
@@ -164,6 +167,9 @@ class LicenseUtil(object):
         if not description_output:
             description_output = """# Output of software license introspection started from {}""".format(pkgnames)
 
+        output_header = "{}\n# Environment this file was generated on:\n# - OS: {}\n# - ROS root: {}".format(
+            description_output, self._os_detect.detect_os(), get_ros_root())
+
         pkgnames_versions = []
         for pkgname in pkgnames:
             try:
@@ -177,7 +183,7 @@ class LicenseUtil(object):
 
         path_outputfile = '{}-{}.yml'.format(prefix_outfile, pkgnames_versions_str)
         with open(path_outputfile, 'w') as outfile:
-            outfile.write("{}\n".format(description_output))
+            outfile.write("{}\n".format(output_header))
             yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)
             logging.debug("Result saved at {}".format(path_outputfile))
         return licenses, path_outputfile

--- a/test/catkin_package_tests/p1/baa/licenses_baa-0.1.2.yml
+++ b/test/catkin_package_tests/p1/baa/licenses_baa-0.1.2.yml
@@ -1,0 +1,2 @@
+Apache2, LGPL:
+- baa

--- a/test/catkin_package_tests/p1/baa/package.xml
+++ b/test/catkin_package_tests/p1/baa/package.xml
@@ -1,0 +1,21 @@
+<package>
+  <name>baa</name>
+  <version>0.1.2</version>
+  <description>
+    I AM THE VERY MODEL OF A MODERN MINOR GENERAL
+  </description>
+  <maintainer email="someone@example.com">Someone</maintainer>
+
+  <license>Apache2</license>
+  <license>LGPL</license>
+
+  <url type="website">http://wiki.ros.org/my_package</url>
+  <url type="bugtracker">http://www.github.com/my_org/my_package/issues</url>
+  <author email="jane.doe@example.com">Jane Doe</author>
+
+  <build_depend>cmake</build_depend>
+  <build_depend>pkg-config</build_depend>
+  <test_depend>gtest</test_depend>
+
+  <export />
+</package>

--- a/test/catkin_package_tests/p1/foo/package.xml
+++ b/test/catkin_package_tests/p1/foo/package.xml
@@ -16,7 +16,6 @@
 
   <build_depend>catkin</build_depend>
   <build_depend version_gte="1.1" version_lt="2.0">genmsg</build_depend>
-
   <build_depend>libboost-thread-dev</build_depend>
   <run_depend>libboost-thread</run_depend>
 

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -58,3 +58,12 @@ def test_get_manifest():
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
+
+
+def test_get_licenses():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    licenses = manager.get_licenses("foo", implicit=False)
+    # package foo declares these 2 licenses in separate tags, which the dict
+    # get_licenses returns contains as a single string.
+    assert("BSD, LGPL" in licenses)

--- a/test/test_rospkg_sw_licenses.py
+++ b/test/test_rospkg_sw_licenses.py
@@ -1,6 +1,6 @@
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2011, Willow Garage, Inc.
+# Copyright 2018 PlusOne Robotics Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -13,7 +13,7 @@
 #    copyright notice, this list of conditions and the following
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
-#  * Neither the name of Willow Garage, Inc. nor the names of its
+#  * Neither the name of Plus One Robotics, Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -37,34 +37,12 @@ import os
 import rospkg
 
 
-def test_find_packages():
+def test_compare_license():
+    from rospkg import sw_license
     search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
-    pkgnames_test = ["baa", "foo"]
-
-    manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
-    # for backward compatibility a wet package which is not a metapackage is found when searching for MANIFEST_FILE
-    assert(len(manager.list()) == 2)
-    manager = rospkg.rospack.ManifestManager(rospkg.common.STACK_FILE, ros_paths=[search_path])
-    assert(len(manager.list()) == 0)
-    manager = rospkg.rospack.ManifestManager(rospkg.common.PACKAGE_FILE, ros_paths=[search_path])
-
-    for pkg_name in manager.list():
-        assert(pkg_name in pkgnames_test)
-        path = manager.get_path(pkg_name)
-        assert(path == os.path.join(search_path, 'p1', pkg_name))
-
-
-def test_get_manifest():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
-    manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
-    manif = manager.get_manifest("foo")
-    assert(manif.type == "package")
-
-
-def test_get_licenses():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
-    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
-    licenses = manager.get_licenses("foo", implicit=False)
-    # package foo declares these 2 licenses in separate tags, which the dict
-    # get_licenses returns contains as a single string.
-    assert("BSD, LGPL" in licenses)
+    manager = sw_license.LicenseUtil(ros_paths=[search_path])
+    dict_result = [("baa", "licenses_baa-0.1.2.yml")]
+    for res in dict_result:
+        licenses = manager.software_license(res[0])
+        path_outputfile = manager.save_licenses(licenses, res[0])
+        assert(manager.compare_license(path_outputfile, "{}/p1/{}/{}".format(search_path, res[0], res[1])))


### PR DESCRIPTION
This depends on https://github.com/ros-infrastructure/rospkg/pull/133

DO NOT review code in-depth yet as the implementation is still very ad-hoc. Other than that, thouhgts are appreciated.

**Issue**: #133 DOES return the name of non-ROS packages in the dependency chain of the passed package, but does NOT introspect their software licenses.

**Solution**: With this PR the result of the same `get_licenses` method contains s/w licenses for non-ROS packages.

**Limitation**: Current implementaton depends on `dpkg`, so works only on debians.

**Running example** for `rviz`:
```
root@daf9c8b3ba42:~# sw_licenses rviz
:Path of the output file: /tmp/licenses_rviz-1.11.18.yml

root@daf9c8b3ba42:~# cat /tmp/licenses_rviz-1.11.18.yml
'"BSD" License Boost Software License public domain':
- libpoco-dev
(System package. License not automatically detected):
- eigen
- apr
- lz4
- python-imaging
- gtest
- python-argparse
- python-coverage
- boost
- log4cxx
- yaml-cpp
- python-mock
- liburdfdom-dev
- tinyxml
- libconsole-bridge-dev
- python-qt-bindings
- assimp
- opengl
- assimp-dev
- libogre-dev
BSD:
- rosconsole
- rosparam
- catkin
- actionlib_msgs
- interactive_markers
- rosgraph
- resource_retriever
- cmake_modules
- media_export
- rospack
- urdf_parser_plugin
- class_loader
- tf2_msgs
- tf2
- nav_msgs
- roscpp_traits
- laser_geometry
- gencpp
- actionlib
- roslib
- tf2_py
- topic_tools
- roscpp_serialization
- rosbuild
- rosout
- rostest
- roslaunch
- tf2_ros
- visualization_msgs
- message_generation
- cpp_common
- roswtf
- rostopic
- image_geometry
- genlisp
- genpy
- urdf
- message_filters
- python_qt_binding
- rostime
- message_runtime
- std_msgs
- image_transport
- tf
- rosservice
- rospy
- rosunit
- angles
- map_msgs
- rosbag_storage
- roscpp
- rosgraph_msgs
- roslang
- genmsg
- std_srvs
- pluginlib
- roslz4
- rosconsole_bridge
- rosmaster
- geometry_msgs
- rosmsg
- sensor_msgs
- rosnode
- rosbag
- rosclean
BSD, Creative Commons:
- rviz
BSD-3-Clause BSD-4-Clause ISC curl:
- curl
BSD-3-clause:
- liburdfdom-headers-dev
Expat LGPL public-domain:
- python-nose
GPL:
- bzip2
- pkg-config
GPL LGPL:
- python-empy
GPL LGPL-2.1:
- python-urlgrabber
GPL-2:
- cmake
GPL-2 GPL-3 LGPL-2.1:
- libqt4-dev
- qt4-qmake
- libqt4-opengl-dev
GPL-2 LGPL-3:
- graphviz
GPL-compatible GPL-compatible licenses:
- python
LGPL-2.1:
- xmlrpcpp
- python-paramiko
MIT license:
- python-netifaces
public domain:
- python-numpy
unknown:
- python-yaml
- python-opencv
- python-rospkg
- libopencv-dev
- python-catkin-pkg
- python-rosdep
- python-wxtools
```
