### PR TITLE
Fix get_depends returning 1st run) none then on 2nd run) fewer pkgs

### DIFF
--- a/src/rospkg/common.py
+++ b/src/rospkg/common.py
@@ -45,15 +45,21 @@ class ResourceNotFound(Exception):
     A ROS filesystem resource was not found.
     """
 
-    def __init__(self, msg, ros_paths=None, list_deps_sofar=None):
+    def __init__(self, msg, ros_paths=None, deps_sofar=None, deps_unavailable=None):
         """
-        :type list_deps_sofar: [str]
-        :param list_deps_sofar: List of depended packages at the time the command
-                                               stopped due to this exception.
+        :type deps_sofar: [str]
+        :param deps_sofar: List of depended packages at the time the command
+                           stopped due to this exception.
+        :type deps_unavailable: [str]
+        :param deps_unavailable: List of packages defined in the dependency but are not
+                                 available on the platform.
         """
         super(ResourceNotFound, self).__init__(msg)
         self.ros_paths = ros_paths
-        self.list_deps_sofar = list_deps_sofar
+        self.deps_sofar = deps_sofar
+        self.deps_unavailable = set()
+        if deps_unavailable:
+            self.deps_unavailable.update(deps_unavailable)
 
     def __str__(self):
         s = self.args[0]  # python 2.6
@@ -61,3 +67,6 @@ class ResourceNotFound(Exception):
             for i, p in enumerate(self.ros_paths):
                 s = s + '\nROS path [%s]=%s' % (i, p)
         return s
+
+    def get_depends(self):
+        return self.deps_sofar

--- a/src/rospkg/common.py
+++ b/src/rospkg/common.py
@@ -45,9 +45,15 @@ class ResourceNotFound(Exception):
     A ROS filesystem resource was not found.
     """
 
-    def __init__(self, msg, ros_paths=None):
+    def __init__(self, msg, ros_paths=None, list_deps_sofar=None):
+        """
+        :type list_deps_sofar: [str]
+        :param list_deps_sofar: List of depended packages at the time the command
+                                               stopped due to this exception.
+        """
         super(ResourceNotFound, self).__init__(msg)
         self.ros_paths = ros_paths
+        self.list_deps_sofar = list_deps_sofar
 
     def __str__(self):
         s = self.args[0]  # python 2.6

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -126,7 +126,6 @@ class ManifestManager(object):
 
         self._manifests = {}
         self._depends_cache = {}
-        self._depends_unavailable = []
         self._rosdeps_cache = {}
         self._location_cache = None
         self._custom_cache = {}
@@ -165,10 +164,7 @@ class ManifestManager(object):
         if name in self._manifests:
             return self._manifests[name]
         else:
-            try:
-                return self._load_manifest(name)
-            except ResourceNotFound as e:
-                raise e
+            return self._load_manifest(name)
 
     def _update_location_cache(self):
         global _cache_lock
@@ -212,11 +208,7 @@ class ManifestManager(object):
         """
         :raises: :exc:`ResourceNotFound`
         """
-        retval = None
-        try:
-            retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
-        except ResourceNotFound as e:
-            raise e
+        retval = self._manifests[name] = parse_manifest_file(self.get_path(name), self._manifest_name, rospack=self)
         return retval
 
     def get_depends(self, name, implicit=True):
@@ -241,14 +233,15 @@ class ManifestManager(object):
             # assign key before recursive call to prevent infinite case
             self._depends_cache[name] = s = set()
 
+            depends_unavailable = set()
+
             # take the union of all dependencies
             names = None
             try:
                 names = [p.name for p in self.get_manifest(name).depends]
             except ResourceNotFound as e:
                 del self._depends_cache[name]
-                self._depends_unavailable.append(name)
-                e.list_deps_sofar = self._depends_unavailable
+                e.deps_unavailable.add(name)
                 raise e
 
             for p in names:
@@ -256,21 +249,24 @@ class ManifestManager(object):
                 try:
                     deps = self.get_depends(p, implicit)
                 except ResourceNotFound as e:
-                    deps = e.list_deps_sofar
-                s.update(deps)
+                    deps = e.get_depends()
+                    depends_unavailable.update(e.deps_unavailable)
+                if deps:
+                    s.update(deps)
             # add in our own deps
             s.update(names)
             # cache the return value as a list
             s = list(s)
             self._depends_cache[name] = s
-            if 0 < len(self._depends_unavailable) or 0 == len(s):
+            if 0 < len(depends_unavailable) or 0 == len(s):
                 raise ResourceNotFound(
-                    "Pkg(s) {} not available on your environment.\n"
+                    "Pkg(s) {0} not available on your environment.\n"
                     "Defined dependency can be obtained in "
-                    "ResourceNotFound.list_deps_sofar: {}".format(
-                        self._depends_unavailable, s),
+                    "ResourceNotFound.get_depends: {1}".format(
+                        list(depends_unavailable), s),
                     ros_paths=self._ros_paths,
-                    list_deps_sofar=s)
+                    deps_sofar=s,
+                    deps_unavailable=depends_unavailable)
             return s
 
     def get_depends_on(self, name, implicit=True):


### PR DESCRIPTION
**Issue**: As described in https://github.com/ros-infrastructure/rospkg/issues/142.

**Suggested solution**
- Add a partial fix in this PR.
  - On 1st run, return all dependencies that are already captured by the time traversing dependency terminates (w/o this PR, no dependency returns).
  - On 2nd run, return all dependencies that are supposed to be returned (w/o this PR, only part of dependency returns).
- To fully fix, https://github.com/ros-infrastructure/rospkg/pull/141 is also needed (but following the discussion in https://github.com/ros-infrastructure/rospkg/pull/129, I split PRs).

Note that I'm not adding a test case for this specific issue. To reproduce this issue requires traversing the dependency chain AFAICT, but looks like CI environment is kept plain so no ros pkgs are installed thus hard to replicate the environment. `get_depends` is tested in multiple test cases (e.g. [test_rospkg_packages.py](https://github.com/ros-infrastructure/rospkg/blob/8bfc04ae7062f7e4e4046f0175f60d2930f37f7a/test/test_rospkg_packages.py#L211)).

**Output**
- Without this PR

See the output in https://github.com/ros-infrastructure/rospkg/issues/142#issue-328116267

- With this PR
```
root@d5a64a312993:~# SRCDIR=~/cws/src && mkdir -p $SRCDIR && git clone https://github.com/plusone-robotics/rospkg -b fix_get_depends_issue142
root@d5a64a312993:~/cws/src/rospkg# export PYTHONPATH=$SRCDIR/rospkg/src:$PYTHONPATH
root@d5a64a312993:~/cws/src/rospkg# export PATH=$SRCDIR/rospkg/scripts:$PATH
root@d5a64a312993:~/cws/src/rospkg# ipython

In [1]: import rospkg
In [2]: rp = rospkg.RosPack()
In [3]: rp.get_depends("roscpp")
---------------------------------------------------------------------------
ResourceNotFound                          Traceback (most recent call last)
<ipython-input-3-b793dd583b6b> in <module>()
----> 1 rp.get_depends("roscpp")

/root/cws/src/rospkg/src/rospkg/rospack.py in get_depends(self, name, implicit)
    267                     ros_paths=self._ros_paths,
        268                     deps_sofar=s,
--> 269                     deps_unavailable=depends_unavailable)
    270             return s
        271

ResourceNotFound: Pkg(s) ['roslang', 'rosunit'] not available on your environment.
Defined dependency can be obtained in ResourceNotFound.get_depends: ['rosgraph_msgs', 'genlisp', 'genpy', 'genmsg', 'catkin', 'rosconsole', 'gencpp', 'xmlrpcpp', 'rostime', 'roslang', 'message_runtime', 'std_msgs', 'geneus', 'gennodejs', 'roscpp_traits', 'roscpp_serialization', 'rosbuild', 'message_generation', 'cpp_common', 'rosunit']
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/opt/ros/melodic/share

In [4]: rp.get_depends("roscpp")
Out[4]:
['rosgraph_msgs',
 'genlisp',
 'genpy',
 'genmsg',
 'catkin',
 'rosconsole',
 'gencpp',
 'xmlrpcpp',
 'rostime',
 'roslang',
 'message_runtime',
 'std_msgs',
 'geneus',
 'gennodejs',
 'roscpp_traits',
 'roscpp_serialization',
 'rosbuild',
 'message_generation',
 'cpp_common',
 'rosunit']
```
