### PR TITLE
[doc] Update installation section

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -60,6 +60,28 @@ Common API
 Installation
 ------------
 
+Recommended automated installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rospkg`` is already dependend by many core packages of ROS, so it should get automatically installed when you follow standard installation steps.
+
+Automated installation is realized by adding a dependency like this:
+
+In ``package.xml`` `format 1 <http://www.ros.org/reps/rep-0127.html>`_:
+
+::
+
+    <run_depend>python-rospkg</run_depend>
+
+In ``package.xml`` `format 2 <http://www.ros.org/reps/rep-0140.html>`_, `format 3 <http://www.ros.org/reps/rep-0149.html#exec-depend-multiple>`_:
+
+::
+
+    <exec_depend>python-rospkg</exec_depend>
+
+Manual installation
+~~~~~~~~~~~~~~~~~~~
+
 rospkg is available on pypi and can be installed via ``pip``
 ::
 

--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -63,7 +63,7 @@ Installation
 Recommended automated installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``rospkg`` is already dependend by many core packages of ROS, so it should get automatically installed when you follow standard installation steps.
+``rospkg`` is already a dependency of many core packages of ROS, so it should get automatically installed when you follow standard installation steps.
 
 Automated installation is realized by adding a dependency like this:
 

--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -93,6 +93,11 @@ or ``easy_install``:
 
     easy_install -U rospkg
 
+For debian-based OSes it's available via apt.
+::
+
+    apt-get install python-rospkg
+
 Using rospkg
 ------------
 


### PR DESCRIPTION
**Motivation**: Following can be the issue for some other pkgs as well, not just `rospkg`, but as a standalone pkg, it should still make sense to be documented within its own document.
- rosdep key (`python-rospkg`) and the pkg name is different. I noticed some people get confused how to install the binary. So clarifying the binary package name can help .
- I noticed some people don't fully utilize resolving dependency via rosdep (they end up not defining keys in `package.xml` and every time run e.g. `apt`).
