### PR TITLE
Fix alpine linux detection

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -696,7 +696,7 @@ OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
 OS_WINDOWS = 'windows'
 
-OsDetect.register_default(OS_ALPINE, FdoDetect("Alpine Linux"))
+OsDetect.register_default(OS_ALPINE, FdoDetect("alpine"))
 OsDetect.register_default(OS_ARCH, Arch())
 OsDetect.register_default(OS_MANJARO, Manjaro())
 OsDetect.register_default(OS_CENTOS, Centos())


### PR DESCRIPTION
This PR fixes OS detection on Alpine Linux.

`rosdep update` failed on Alpine showing an error pasted below.
`FdoDetect` checks ID field in `/etc/os-release` (which is defined as "alpine") and `FdoDetect` was constructed with ID of "Alpine Linux".

I'm trying to add alpine support to rosdep and rosdistro.
A working demo to install dependent package on alpine using `rosdep` is placed at https://github.com/at-wat/alpine-ros.

FYI: @Minipada
ref: #137

```
/ # apk add py-pip git
/ # pip install rosdep git+https://github.com/ros-infrastructure/rospkg.git
/ # rosdep init
/ # rosdep update
reading in sources list data from /etc/ros/rosdep/sources.list.d
Warning: running 'rosdep update' as root is not recommended.
  You should run 'sudo rosdep fix-permissions' and invoke 'rosdep update' again without sudo.
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/osx-homebrew.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/python.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/ruby.yaml
Hit https://raw.githubusercontent.com/ros/rosdistro/master/releases/fuerte.yaml
Query rosdistro index https://raw.githubusercontent.com/ros/rosdistro/master/index.yaml
Add distro "groovy"

ERROR: Rosdep experienced an error: Could not detect OS, tried ['windows', 'ubuntu', 'slackware', 'rhel', 'qnx', 'osx', 'tizen', 'opensuse', 'opensuse', 'opensuse', 'neon', 'mint', 'linaro', 'gentoo', 'funtoo', 'freebsd', 'fedora', 'elementary', 'elementary', 'debian', 'cygwin', 'centos', 'manjaro', 'arch', 'alpine']
Please go to the rosdep page [1] and file a bug report with the stack trace below.
[1] : http://www.ros.org/wiki/rosdep

rosdep version: 0.12.2

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/rosdep2/main.py", line 140, in rosdep_main
    exit_code = _rosdep_main(args)
  File "/usr/lib/python2.7/site-packages/rosdep2/main.py", line 386, in _rosdep_main
    return _no_args_handler(command, parser, options, args)
  File "/usr/lib/python2.7/site-packages/rosdep2/main.py", line 395, in _no_args_handler
    return command_handlers[command](options)
  File "/usr/lib/python2.7/site-packages/rosdep2/main.py", line 592, in command_update
    error_handler=update_error_handler)
  File "/usr/lib/python2.7/site-packages/rosdep2/sources_list.py", line 490, in update_sources_list
    rosdep_data = get_gbprepo_as_rosdep_data(dist_name)
  File "/usr/lib/python2.7/site-packages/rosdep2/gbpdistro_support.py", line 150, in get_gbprepo_as_rosdep_data
    ctx = create_default_installer_context()
  File "/usr/lib/python2.7/site-packages/rosdep2/__init__.py", line 87, in create_default_installer_context
    m.register_platforms(context)
  File "/usr/lib/python2.7/site-packages/rosdep2/platforms/debian.py", line 53, in register_platforms
    register_linaro(context)
  File "/usr/lib/python2.7/site-packages/rosdep2/platforms/debian.py", line 70, in register_linaro
    (os_name, os_version) = context.get_os_name_and_version()
  File "/usr/lib/python2.7/site-packages/rosdep2/installers.py", line 115, in get_os_name_and_version
    os_name = self.os_detect.get_name()
  File "/usr/lib/python2.7/site-packages/rospkg/os_detect.py", line 660, in get_name
    self.detect_os()
  File "/usr/lib/python2.7/site-packages/rospkg/os_detect.py", line 630, in detect_os
    raise OsNotDetected("Could not detect OS, tried %s" % attempted)
OsNotDetected: Could not detect OS, tried ['windows', 'ubuntu', 'slackware', 'rhel', 'qnx', 'osx', 'tizen', 'opensuse', 'opensuse', 'opensuse', 'neon', 'mint', 'linaro', 'gentoo', 'funtoo', 'freebsd', 'fedora', 'elementary', 'elementary', 'debian', 'cygwin', 'centos', 'manjaro', 'arch', 'alpine']
```