### PR TITLE
Use console_scripts for a portable way to generate rosversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ kwargs = {
     'version': '1.1.4',
     'packages': ['rospkg'],
     'package_dir': {'': 'src'},
-    'scripts': ['scripts/rosversion'],
+    'entry_points': {
+        'console_scripts': ['rosversion=rospkg.rosversion:main'],
+    },
     'install_requires': ['catkin_pkg', 'PyYAML'],
     'author': 'Ken Conley',
     'author_email': 'kwc@willowgarage.com',

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -430,8 +430,8 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
 
         return manifest
 
-    with open(filename, 'rb') as f:
-        return parse_manifest(manifest_name, f.read().decode('utf-8'), filename)
+    with open(filename, 'r') as f:
+        return parse_manifest(manifest_name, f.read(), filename)
 
 
 def parse_manifest(manifest_name, string, filename='string'):

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -430,8 +430,8 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
 
         return manifest
 
-    with open(filename, 'r') as f:
-        return parse_manifest(manifest_name, f.read(), filename)
+    with open(filename, 'rb') as f:
+        return parse_manifest(manifest_name, f.read().decode('utf-8'), filename)
 
 
 def parse_manifest(manifest_name, string, filename='string'):

--- a/src/rospkg/rosversion.py
+++ b/src/rospkg/rosversion.py
@@ -88,7 +88,7 @@ def main():
         help='Output the ROS distribution name')
 
     args = parser.parse_args()
-                
+
     printer = print_without_newline if args.skip_newline else print
 
     if args.distro:

--- a/src/rospkg/rosversion.py
+++ b/src/rospkg/rosversion.py
@@ -70,6 +70,7 @@ def print_without_newline(argtext):
     """Print with no new line."""
     print(argtext, end='')
 
+
 def main():
     parser = argparse.ArgumentParser(
         description='rosversion -d: Output the version of the given package\n'


### PR DESCRIPTION
In Windows, the shebang python script without file extension cannot be run directly. Either user needs to create a batch script as a shim or we can use console_scripts to generate portable rosversion (in Windows, it will be a executable shim.)

This pull request is to propose to use console_scripts.