### PR TITLE
os.environ = environ_copy does not work as expected

### DIFF
--- a/test/test_rospkg_packages.py
+++ b/test/test_rospkg_packages.py
@@ -166,7 +166,8 @@ def test_RosPack_no_env():
         except ResourceNotFound:
             pass
     finally:
-        os.environ = environ_copy
+        os.environ.clear()
+        os.environ.update(environ_copy)
 
 
 def test_RosPack_get_path():


### PR DESCRIPTION
This code seems to expect temporary store the env variable and store it, but substitute os.environ for environ_copy does not work
c.f. https://stackoverflow.com/questions/2059482/python-temporarily-modify-the-current-processs-environment

you can easily confirm this with
```
(venv) k-okada@p51s:~/catkin_ws/ws_rqt/rospkg$ cat test/noenv.py 
#!/usr/bin/env python

import subprocess
import os

def run_rospack():
    stdout, stderr = subprocess.Popen(['rospack', 'list-names'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
    print("finish : len(stdout) %d len(stdin) %d" % (len(stdout), len(stderr)))

print("run rospack")
run_rospack()

environ_copy = os.environ.copy()
if 'ROS_ROOT' in os.environ:
    del os.environ['ROS_ROOT']
if 'ROS_PACKAGE_PATH' in os.environ:
    del os.environ['ROS_PACKAGE_PATH']

print("run rospack after env delete")
run_rospack()

os.environ = environ_copy
print("run rospack after os.environ = environ_copy")
run_rospack() # ng
(venv) k-okada@p51s:~/catkin_ws/ws_rqt/rospkg$ ./test/noenv.py 
run rospack
finish : len(stdout) 9003 len(stdin) 0
run rospack after env delete
finish : len(stdout) 0 len(stdin) 0
run rospack after os.environ = environ_copy
finish : len(stdout) 0 len(stdin) 0
```
and fixed by using `os.environ.update()`
```
(venv) k-okada@p51s:~/catkin_ws/ws_rqt/rospkg$ cat test/noenv.py 
#!/usr/bin/env python

import subprocess
import os

def run_rospack():
    stdout, stderr = subprocess.Popen(['rospack', 'list-names'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
    print("finish : len(stdout) %d len(stdin) %d" % (len(stdout), len(stderr)))

print("run rospack")
run_rospack()

environ_copy = os.environ.copy()
if 'ROS_ROOT' in os.environ:
    del os.environ['ROS_ROOT']
if 'ROS_PACKAGE_PATH' in os.environ:
    del os.environ['ROS_PACKAGE_PATH']

print("run rospack after env delete")
run_rospack()

'''
os.environ = environ_copy
print("run rospack after os.environ = environ_copy")
run_rospack() # ng
'''

os.environ.clear()
os.environ.update(environ_copy)
print("run rospack after os.environ = environ_copy")
run_rospack()
(venv) k-okada@p51s:~/catkin_ws/ws_rqt/rospkg$ ./test/noenv.py 
run rospack
finish : len(stdout) 9003 len(stdin) 0
run rospack after env delete
finish : len(stdout) 0 len(stdin) 0
run rospack after os.environ = environ_copy
finish : len(stdout) 9003 len(stdin) 0
```

As as side effect, this will fail in nosetests.
```
(venv) k-okada@p51s:~/catkin_ws/ws_rqt/rospkg$ nosetests -s -v test/test_rospkg_packages.py
test.test_rospkg_packages.get_package_test_path ... ok
test.test_rospkg_packages.test_ManifestManager_constructor ... ok
test.test_rospkg_packages.test_ManifestManager_get_instance ... ok
test.test_rospkg_packages.test_RosPack_list ... ok
test.test_rospkg_packages.test_RosPack_no_env ... ok
test.test_rospkg_packages.test_RosPack_get_path ... ROS path: /home/k-okada/catkin_ws/ws_rqt/rospkg/test/package_tests
ROS_PATH 1: /home/k-okada/catkin_ws/ws_rqt/rospkg/test/package_tests/p1
ROS_PATH 2: /home/k-okada/catkin_ws/ws_rqt/rospkg/test/package_tests/p2
ok
test.test_rospkg_packages.test_RosPackage_get_depends ... FAIL
test.test_rospkg_packages.get_stack_test_path ... ok
test.test_rospkg_packages.test_stack_of ... ok
test.test_rospkg_packages.test_RosPackage_get_depends_explicit ... FAIL
test.test_rospkg_packages.test_RosPack_get_rosdeps ... ok
test.test_rospkg_packages.test_get_package_name ... ok
test.test_rospkg_packages.test_get_depends_on ... FAIL

======================================================================
FAIL: test.test_rospkg_packages.test_RosPackage_get_depends
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/k-okada/catkin_ws/ws_rqt/rospkg/test/test_rospkg_packages.py", line 238, in test_RosPackage_get_depends
    assert retval == rospackval, "[%s]: %s vs. %s" % (p, retval, rospackval)
AssertionError: [actionlib]: set(['rosconsole', 'rosparam', 'catkin', 'genlisp', 'actionlib_msgs', 'rosgraph', 'cmake_modules', 'rospack', 'rosbuild', 'roscpp', 'gencpp', 'rosgraph_msgs', 'roslib', 'geneus', 'roscpp_serialization', 'roscpp_traits', 'rosout', 'rostest', 'rostopic', 'message_generation', 'cpp_common', 'roslang', 'roslz4', 'ros_environment', 'genpy', 'rostime', 'message_runtime', 'std_msgs', 'rospy', 'rosunit', 'rosbag_storage', 'roslaunch', 'genmsg', 'std_srvs', 'xmlrpcpp', 'gennodejs', 'topic_tools', 'rosmaster', 'rosnode', 'rosbag', 'rosclean']) vs. set([u'rosconsole', u'rosparam', u'catkin', u'genlisp', u'actionlib_msgs', u'rosgraph', u'rostest', u'rosout', u'rospack', u'rosbuild', u'roscpp', u'gencpp', u'roslib', u'geneus', u'roscpp_serialization', u'roscpp_traits', u'topic_tools', u'rosclean', u'rostopic', u'message_generation', u'cpp_common', u'ros_environment', u'genpy', u'rostime', u'message_runtime', u'std_msgs', u'rospy', u'rosunit', u'rosbag_storage', u'rosgraph_msgs', u'genmsg', u'std_srvs', u'xmlrpcpp', u'roslaunch', u'gennodejs', u'roslz4', u'rosmaster', u'rosbag'])
...
```

because `rospack name-list` returns (maybe) only `run_depends` and rospkg.get_depend returns `build, run, test buidltool depends`
https://github.com/ros-infrastructure/rospkg/blob/633e19ae54f1a9aeb59080e348a356054a7df600/src/rospkg/manifest.py#L419
