### PR TITLE
remove Ubuntu distros older than Trusty, remove Debian Wheezy

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,7 +10,7 @@ Depends: python-argparse, python-catkin-pkg, python-rospkg-modules (>= 1.1.5)
 Depends3: python3-catkin-pkg, python3-rospkg-modules (>= 1.1.5)
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -21,6 +21,6 @@ Conflicts: python-rospkg (<< 1.1.0)
 Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
 X-Python3-Version: >= 3.2
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Related to ros-infrastructure/catkin_pkg#232.

Basically the toolchain on Bionic embeds a Python dependency on version >= 2.7.5 which isn't available on Ubuntu Precise / Debian Wheezy. At the same time it removes other EOL Ubuntu distro before the last supported LTS which is currently Ubuntu Trusty.