### PR TITLE
fix packaging of rosversion entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ if 'SKIP_PYTHON_MODULES' in os.environ:
 if 'SKIP_PYTHON_SCRIPTS' in os.environ:
     kwargs['name'] += '_modules'
     kwargs['scripts'] = []
+    kwargs['entry_points']['console_scripts'] = []
 
 setup(**kwargs)


### PR DESCRIPTION
Fix regression of #150.

Without this change the `rosversion` script is being packages in both the `python(3)-rospkg` as well as the `python(3)-rospkg-modules` Debian package which makes them uninstallable.