### PR TITLE
Add os-release fall back and Clear Linux distro.

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -71,23 +71,25 @@ def read_issue(filename="/etc/issue"):
     return None
 
 
-def read_os_release(filename=""):
+def read_os_release(filename=None):
     """
-    :returns: Dictonary of key value pairs from /etc/os-release or fallback to /usr/lib/os-release, with quotes stripped from values
+    :returns: Dictionary of key value pairs from /etc/os-release or fallback to 
+      /usr/lib/os-release, with quotes stripped from values
     """
-    release_info = {}
-    if not filename:
-        filename = "/etc/os-release"
+    if filename is None:
+        filename = '/etc/os-release'
         if not os.path.exists(filename):
-            filename = "/usr/lib/os-release"
+            filename = '/usr/lib/os-release'
 
-    if os.path.exists(filename):
-        with codecs.open(filename, 'r', encoding=locale.getpreferredencoding()) as f:
-            for line in f:
-                key, val = line.rstrip('\n').partition('=')[::2]
-                release_info[key] = val.strip('"')
-            return release_info
-    return None
+    if not os.path.exists(filename):
+        return None
+
+    release_info = {}
+    with codecs.open(filename, 'r', encoding=locale.getpreferredencoding()) as f:
+        for line in f:
+            key, val = line.rstrip('\n').partition('=')[::2]
+            release_info[key] = val.strip('"')
+    return release_info
 
 
 class OsNotDetected(Exception):

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -700,6 +700,7 @@ OS_RHEL = 'rhel'
 OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
 OS_WINDOWS = 'windows'
+OS_CLEARLINUX = 'clearlinux'
 
 OsDetect.register_default(OS_ALPINE, FdoDetect("alpine"))
 OsDetect.register_default(OS_ARCH, Arch())
@@ -725,6 +726,7 @@ OsDetect.register_default(OS_QNX, QNX())
 OsDetect.register_default(OS_RHEL, Rhel())
 OsDetect.register_default(OS_SLACKWARE, Slackware())
 OsDetect.register_default(OS_UBUNTU, LsbDetect("Ubuntu"))
+OsDetect.register_default(OS_CLEARLINUX, FdoDetect("clear-linux-os"))
 OsDetect.register_default(OS_WINDOWS, Windows())
 
 

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -71,11 +71,16 @@ def read_issue(filename="/etc/issue"):
     return None
 
 
-def read_os_release(filename="/etc/os-release"):
+def read_os_release(filename=""):
     """
-    :returns: Dictonary of key value pairs from /etc/os-release, with quotes stripped from values
+    :returns: Dictonary of key value pairs from /etc/os-release or fallback to /usr/lib/os-release, with quotes stripped from values
     """
     release_info = {}
+    if not filename:
+        filename = "/etc/os-release"
+        if not os.path.exists(filename):
+            filename = "/usr/lib/os-release"
+
     if os.path.exists(filename):
         with codecs.open(filename, 'r', encoding=locale.getpreferredencoding()) as f:
             for line in f:


### PR DESCRIPTION
To integrate rospkg to Clear Linux it is need to improve the os_detect.py.

* A fall back location of os-release was added following
  the freedesktop os-release manual. 

* The entry of Clear Linux distro was added.