### PR TITLE
Clean up shebang warnings

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2009, Willow Garage, Inc.
 # All rights reserved.
 #

--- a/src/rospkg/rosversion.py
+++ b/src/rospkg/rosversion.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright (c) 2008, Willow Garage, Inc.
 # All rights reserved.
 #


### PR DESCRIPTION
These are minor clean-ups for issues discovered during Fedora packaging. To date, these issues have been addressed in the packaging workflow directly. Moving the changes upstream means we can remove the workarounds in the packaging workflows.

Examples of the errors we're seeing from rpmlint:
```
python2-rospkg.noarch: E: non-executable-script /usr/lib/python2.7/site-packages/rospkg/os_detect.py 644 /usr/bin/python2 
python2-rospkg.noarch: E: non-executable-script /usr/lib/python2.7/site-packages/rospkg/rosversion.py 644 /usr/bin/python2
```

There are two related changes here:
1. `os_detect.py` has a shebang and `__main__`, but isn't executable. Either:
   a. The shebang should be removed **(this is the change I'm proposing, after feedback)**
   b. The file should be made executable ~~(this is the change I'm proposing)~~
2. `rosversion.py` has a shebang, but no `__main__` handler. Either:
   a. The shebang should be removed (this is the change I'm proposing)
   b. `__main__` should be added and the file should be made executable. Since `console_scripts` takes care of this at installation time, I don't think this is the right thing to do.