### PR TITLE
WIP: Add license introspection feature

### DIFF
--- a/scripts/sw_licenses
+++ b/scripts/sw_licenses
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Copyright 2018 PlusOne Robotics Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of the PlusOne Robotics Inc. nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import argparse
+import logging
+import sys
+
+from rospkg.sw_license import  LicenseUtil
+
+PATH_PREFIX_OUTPUT = "/tmp/licenses"
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description=
+                                     'List the OSS licenses of all ROS dependency for the given package.')
+    parser.add_argument(
+        'pkg_name', help='Package that starts tracking from to get the all licenses of.')
+    parser.add_argument(
+        '--path_licenses_prev',
+        help="Path of a file to be compared from. Run comparison if this is passed.")
+    parser.add_argument(
+        '--prefix_outfile', help='Prefix of the output file in an absolute path.'
+        ' By default it is {}'.format(PATH_PREFIX_OUTPUT),
+        default="{}".format(PATH_PREFIX_OUTPUT))
+    args = parser.parse_args()
+    license_util = LicenseUtil()
+    dict_licenses = license_util.software_license(args.pkg_name)
+    licenses, path_licenses = license_util.save_licenses(
+        dict_licenses, args.pkg_name, prefix_outfile=args.prefix_outfile)
+    print("Path of the output file: {}".format(path_licenses))
+    if args.path_licenses_prev:
+        ret = license_util.compare_license(args.path_licenses_prev, path_licenses)
+        if not ret:
+            logging.error("New license found. Exiting with 1.")
+            sys.exit(1)

--- a/scripts/sw_licenses
+++ b/scripts/sw_licenses
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=
                                      'List the OSS licenses of all ROS dependency for the given package.')
     parser.add_argument(
-        'pkg_name', help='Package that starts tracking from to get the all licenses of.')
+        'pkg_names', help="Packages that start from to get the all licenses of. Delimit by comma and enclose the entire list by double quote when multiple packages passed. Result will be consolidated into one file.")
     parser.add_argument(
         '--path_licenses_prev',
         help="Path of a file to be compared from. Run comparison if this is passed.")
@@ -50,9 +50,9 @@ if __name__ == "__main__":
         default="{}".format(PATH_PREFIX_OUTPUT))
     args = parser.parse_args()
     license_util = LicenseUtil()
-    dict_licenses = license_util.software_license(args.pkg_name)
+    dict_licenses = license_util.software_license(args.pkg_names)
     licenses, path_licenses = license_util.save_licenses(
-        dict_licenses, args.pkg_name, prefix_outfile=args.prefix_outfile)
+        dict_licenses, args.pkg_names, prefix_outfile=args.prefix_outfile)
     print("Path of the output file: {}".format(path_licenses))
     if args.path_licenses_prev:
         ret = license_util.compare_license(args.path_licenses_prev, path_licenses)

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -42,7 +42,7 @@ import xml.dom.minidom as dom
 from .common import MANIFEST_FILE, PACKAGE_FILE, STACK_FILE
 
 # stack.xml and manifest.xml have the same internal tags right now
-REQUIRED = ['license']
+REQUIRED = ['license', "name"]
 ALLOWXHTML = ['description']
 OPTIONAL = ['author', 'logo', 'url', 'brief', 'description', 'status',
             'notes', 'depend', 'rosdep', 'export', 'review',
@@ -318,7 +318,7 @@ class Manifest(object):
         'author', 'license', 'license_url', 'url',
         'depends', 'rosdeps', 'platforms',
         'exports', 'version',
-        'status', 'notes',
+        'status', 'name', 'notes',
         'unknown_tags', 'type', 'filename',
         'is_catkin']
 
@@ -331,7 +331,7 @@ class Manifest(object):
         self.description = self.brief = self.author = \
             self.license = self.license_url = \
             self.url = self.status = \
-            self.version = self.notes = ''
+            self.version = self.notes = self.name = ''
         self.depends = []
         self.rosdeps = []
         self.exports = []
@@ -395,6 +395,7 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
         p = parse_package(package_filename)
         # put these into manifest
         manifest.description = p.description
+        manifest.name = p.name
         manifest.author = ', '.join([('Maintainer: %s' % str(m)) for m in p.maintainers] + [str(a) for a in p.authors])
         manifest.license = ', '.join(p.licenses)
         if p.urls:
@@ -497,6 +498,7 @@ def parse_manifest(manifest_name, string, filename='string'):
         pass  # manifest is missing optional 'review notes' tag
 
     m.author = _check('author', True)(p, filename)
+    m.name = _check("name")(p, filename)
     m.url = _check('url')(p, filename)
     m.version = _check('version')(p, filename)
 

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 import os
 from threading import Lock
 from xml.etree.cElementTree import ElementTree
@@ -425,7 +425,18 @@ class RosPack(ManifestManager):
             else:
                 license_dict[MSG_LICENSE_NOTFOUND_SYSPKG].append(pkgname_rosdep)
 
-        licenses = license_dict.items()
+        # Sort pkg names in each license
+        for list_key in license_dict.values():
+            list_key.sort()
+        # Sort by license name.
+        licenses = OrderedDict(sorted(license_dict.items()))
+
+        # List of tuples converted into yaml can look like the following, which isn't 
+        # that useful. So here converting to a dict.
+        # - !!python/tuple
+        #  - LGPL
+        #   - - python_orocos_kdl
+        #     - orocos_kdl
         return dict(licenses)
 
 

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -31,13 +31,15 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from collections import OrderedDict
+from collections import defaultdict, OrderedDict
 import logging
-from rospkg import ResourceNotFound, RosPack
 import yaml
+
+from rospkg import ResourceNotFound, RosPack
 
 
 class LicenseUtil(object):
+    _URL_ISSUE_RELEVANT = "https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
 
     def __init__(self):
         self.rp = RosPack()
@@ -69,26 +71,77 @@ class LicenseUtil(object):
                 logging.info("License '{}' was present.".format(key))
         return ret
 
-    def software_license(self, pkgname):
+    def software_license(self, pkgnames):
         """
-        @return List of licenses and packages.
+        @type pkgnames: Either one of the following:
+                    - [str]: list of str.
+                    - str str...str: space separated string.
+        @param pkgnames: Name of one or more packages to start software license
+                       introspection from (i.e. leaf packages in the dependency chain).
+        @return List of software licenses found in the dependency chain started from
+                       the package names passed in 'pkgnames'. When multiple packages
+                       passed to start with, union of all the results is returned.
         @raise AttributeError, ResourceNotFound
         """
-        if not pkgname:
-            raise ValueError("Argument was insufficient: pkgname {}".format(pkgname))
-        try:
-            dict_license = self.rp.get_licenses(pkgname)
-        except AttributeError as e:
-            raise e
-        except ResourceNotFound as e:
-            URL_ISSUE_RELEVANT="https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
-            logging.warn("{}\nRe-run get_licenses to work around an issue with get_depends (see {} if needed).".format(repr(e), URL_ISSUE_RELEVANT))
-            dict_license = self.rp.get_licenses(pkgname)
-        logging.debug(dict_license)
-        return dict_license
+        if not pkgnames:
+            raise ValueError("Argument was insufficient: pkgname {}".format(pkgnames))
+
+        # Check if pkgnames is str, not list.
+        if isinstance(pkgnames, basestring):
+            # If space(s) are found, 1) take it as a single package name if only one str
+            # element is found. 2) Convert to [str] if multiple str elements found.
+            pkgnames = pkgnames.split()
+
+        # Could store multiple resulted dicts for a package
+        dicts_of_result = []
+        for pkg_name in pkgnames:
+            try:
+                dict_license = self.rp.get_licenses(pkg_name)
+            except AttributeError as e:
+                raise e
+            except ResourceNotFound as e:
+                logging.warn(
+                    "{}\nRe-running Rospack.get_licenses to work around an issue with"
+                    " get_depends (see {} if needed).".format(
+                        repr(e), self._URL_ISSUE_RELEVANT))
+                dict_license = self.rp.get_licenses(pkg_name)
+            dicts_of_result.append(dict_license)
+
+        # Take the union of the results.
+        dict_licenses = self._union_dicts(dicts_of_result)
+        logging.debug(dict_licenses)
+        return dict_licenses
+
+    def _union_dicts(self, d):
+        """
+        @param *d: dictionaries, each of which needs to be formatted as the output of
+                       rospkg.RosPack.get_licenses (otherwise), i.e. { k, [d] }.
+        @rtype { k, [d] }
+        """
+        # https://stackoverflow.com/a/14766978/577001
+
+        logging.debug("d: {} len(d): {}\n".format(d, len(d)))
+
+        newdicts = defaultdict(set)  # Define a defaultdict
+        for each_dict in d:
+            logging.debug("each_dict: {}\n".format(each_dict))
+            #ordered_dic = OrderedDict(sorted(list(each_dict)[0].items()))
+            ordered_dic = OrderedDict(sorted(each_dict.items()))
+
+            # dict.items() returns a list of (k, v) tuple.
+            # So, you can directly unpack the tuple in two loop variables.
+            for k, v in ordered_dic.items():
+                newdicts[k] |= set(v)
+
+            logging.debug("newdicts: {}\n".format(newdicts))
+        # And if you want the exact representation that you have shown
+        # You can build a normal dict out of your newly built dict.
+        union = {key: sorted(list(value)) for key, value in newdicts.items()}
+        logging.debug(union)
+        return union
 
     def save_licenses(
-            self, licenses, pkgname, implicit=True, sortbylicense=True,
+            self, licenses, pkgnames, implicit=True, sortbylicense=True,
             prefix_outfile="/tmp/licenses", description_output=None):
         """
         @summary:  If True save the result of get_licenses to a text file.
@@ -104,14 +157,25 @@ class LicenseUtil(object):
         @raise ResourceNotFound
         """
         pkg_version = "pkgversion"
-        if not description_output:
-            description_output = "# Output of software license introspection started from {}.".format(pkgname)
 
-        try:
-            pkg_version = self.rp.get_manifest(pkgname).version
-        except Exception as e:
-            print(str(e))
-        path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
+        if isinstance(pkgnames, basestring):
+            pkgnames = pkgnames.split()
+
+        if not description_output:
+            description_output = """# Output of software license introspection started from {}""".format(pkgnames)
+
+        pkgnames_versions = []
+        for pkgname in pkgnames:
+            try:
+                pkg_version = self.rp.get_manifest(pkgname).version
+                pkgnames_versions.append("{}-{}".format(pkgname, pkg_version))
+            except Exception as e:
+                print(str(e))
+
+        # Delimits package name with underscore.
+        pkgnames_versions_str = "_".join(pkgnames_versions)
+
+        path_outputfile = '{}-{}.yml'.format(prefix_outfile, pkgnames_versions_str)
         with open(path_outputfile, 'w') as outfile:
             outfile.write("{}\n".format(description_output))
             yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -88,7 +88,8 @@ class LicenseUtil(object):
         return dict_license
 
     def save_licenses(
-            self, licenses, pkgname, implicit=True, sortbylicense=True, prefix_outfile="/tmp/licenses",):
+            self, licenses, pkgname, implicit=True, sortbylicense=True,
+            prefix_outfile="/tmp/licenses", description_output=None):
         """
         @summary:  If True save the result of get_licenses to a text file.
         @param licenses: TBD
@@ -97,17 +98,22 @@ class LicenseUtil(object):
         @param prefix_outfile: Prefix of the output file in an absolute full path style.
                                               E.g. by default output of pkgA version 1.0.0 will be saved at:
                                                    /tmp/licenses_pkgA-1.0.0.log
+        @param description_output: Description printed at the top of the output file.
         @return 1) License object, 2) Path of the resulted file (either absolute/relative
                        depending on the prefix_outfile)
         @raise ResourceNotFound
         """
         pkg_version = "pkgversion"
+        if not description_output:
+            description_output = "# Output of software license introspection started from {}.".format(pkgname)
+
         try:
             pkg_version = self.rp.get_manifest(pkgname).version
         except Exception as e:
             print(str(e))
         path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
         with open(path_outputfile, 'w') as outfile:
-            yaml.dump(licenses, outfile, default_flow_style=False)
+            outfile.write("{}\n".format(description_output))
+            yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)
             logging.debug("Result saved at {}".format(path_outputfile))
         return licenses, path_outputfile

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -1,0 +1,113 @@
+# Copyright 2018 PlusOne Robotics Inc.
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, PlusOne Robotics, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of PlusOne Robotics, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from collections import OrderedDict
+import logging
+from rospkg import ResourceNotFound, RosPack
+import yaml
+
+
+class LicenseUtil(object):
+
+    def __init__(self):
+        self.rp = RosPack()
+
+    def compare_license(self, path_a="", path_b=""):
+        """
+        @summary Compare 2 files of license output and returns any new license entries.
+        """
+        ret = True
+        stream_a = open(path_a, "r")
+        yaml_a = yaml.load_all(stream_a)
+
+        stream_b = open(path_b, "r")
+        yaml_b = yaml.load_all(stream_b)
+
+        # PyYaml doesn't preserve order of input yaml, so this is needed.
+        # https://github.com/yaml/pyyaml/issues/110
+        ordered_a = OrderedDict(sorted(list(yaml_a)[0].items()))
+        ordered_b = OrderedDict(sorted(list(yaml_b)[0].items()))
+        logging.debug("yaml_a: {}\nyaml_b: {}".format(ordered_a, ordered_b))
+        # What to check?
+        # - Key addition
+        # - Values
+        for key in ordered_a:
+            if key not in ordered_b:
+                logging.error("License '{}' was NOT present in the input file.".format(key))
+                ret = False
+            else:
+                logging.info("License '{}' was present.".format(key))
+        return ret
+
+    def software_license(self, pkgname):
+        """
+        @return List of licenses and packages.
+        @raise AttributeError, ResourceNotFound
+        """
+        if not pkgname:
+            raise ValueError("Argument was insufficient: pkgname {}".format(pkgname))
+        try:
+            dict_license = self.rp.get_licenses(pkgname)
+        except AttributeError as e:
+            raise e
+        except ResourceNotFound as e:
+            URL_ISSUE_RELEVANT="https://github.com/ros-infrastructure/rospkg/pull/129#issue-168007083"
+            logging.warn("{}\nRe-run get_licenses to work around an issue with get_depends (see {} if needed).".format(repr(e), URL_ISSUE_RELEVANT))
+            dict_license = self.rp.get_licenses(pkgname)
+        logging.debug(dict_license)
+        return dict_license
+
+    def save_licenses(
+            self, licenses, pkgname, implicit=True, sortbylicense=True, prefix_outfile="/tmp/licenses",):
+        """
+        @summary:  If True save the result of get_licenses to a text file.
+        @param licenses: TBD
+        @param implicit: Same as the one in get_depends
+        @param sortbylicense: Same as the one in get_licenses
+        @param prefix_outfile: Prefix of the output file in an absolute full path style.
+                                              E.g. by default output of pkgA version 1.0.0 will be saved at:
+                                                   /tmp/licenses_pkgA-1.0.0.log
+        @return 1) License object, 2) Path of the resulted file (either absolute/relative
+                       depending on the prefix_outfile)
+        @raise ResourceNotFound
+        """
+        pkg_version = "pkgversion"
+        try:
+            pkg_version = self.rp.get_manifest(pkgname).version
+        except Exception as e:
+            print(str(e))
+        path_outputfile = '{}_{}-{}.yml'.format(prefix_outfile, pkgname, pkg_version)
+        with open(path_outputfile, 'w') as outfile:
+            yaml.dump(licenses, outfile, default_flow_style=False)
+            logging.debug("Result saved at {}".format(path_outputfile))
+        return licenses, path_outputfile

--- a/src/rospkg/sw_license.py
+++ b/src/rospkg/sw_license.py
@@ -36,6 +36,8 @@ import logging
 import yaml
 
 from rospkg import ResourceNotFound, RosPack
+from rospkg.environment import get_ros_root
+from rospkg.os_detect import OsDetect
 
 
 class LicenseUtil(object):
@@ -43,6 +45,7 @@ class LicenseUtil(object):
 
     def __init__(self):
         self.rp = RosPack()
+        self._os_detect = OsDetect()
 
     def compare_license(self, path_a="", path_b=""):
         """
@@ -164,6 +167,9 @@ class LicenseUtil(object):
         if not description_output:
             description_output = """# Output of software license introspection started from {}""".format(pkgnames)
 
+        output_header = "{}\n# Environment this file was generated on:\n# - OS: {}\n# - ROS root: {}".format(
+            description_output, self._os_detect.detect_os(), get_ros_root())
+
         pkgnames_versions = []
         for pkgname in pkgnames:
             try:
@@ -177,7 +183,7 @@ class LicenseUtil(object):
 
         path_outputfile = '{}-{}.yml'.format(prefix_outfile, pkgnames_versions_str)
         with open(path_outputfile, 'w') as outfile:
-            outfile.write("{}\n".format(description_output))
+            outfile.write("{}\n".format(output_header))
             yaml.dump(licenses, outfile, default_flow_style=False, allow_unicode=True)
             logging.debug("Result saved at {}".format(path_outputfile))
         return licenses, path_outputfile

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -58,3 +58,12 @@ def test_get_manifest():
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
+
+
+def test_get_licenses():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    licenses = manager.get_licenses("foo", implicit=False)
+    # package foo declares these 2 licenses in separate tags, which the dict
+    # get_licenses returns contains as a single string.
+    assert("BSD, LGPL" in licenses)


### PR DESCRIPTION
## What does this PR do

Add a few features.
- license introspection: Find software licenses used in the packages in the dependency chain starting from the package passed. Result will be saved in a yaml file. Limited to target only catkin packages in the chain.
- license comparison: Takes a license introspection result (yaml file), run license introspection and returns new license found.

## Development status

While this depends on https://github.com/ros-infrastructure/rospkg/pull/133, which is not yet merged at the moment, the added features has been in use (from source) on my team for months. So sharing in public early.

Once #133 gets merged this PR will be updated.
