### PR TITLE
[manifest] Use list of str instead of a single str, to handle better packages with multiple licenses.

### DIFF
--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -315,8 +315,8 @@ class Manifest(object):
     """
     __slots__ = [
         'description', 'brief',
-        'author', 'license', 'licenses', 'license_url',
-        'url', 'depends', 'rosdeps', 'platforms',
+        'author', 'license', 'licenses', 'license_url', 'url',
+        'depends', 'rosdeps', 'platforms',
         'exports', 'version',
         'status', 'notes',
         'unknown_tags', 'type', 'filename',
@@ -332,8 +332,8 @@ class Manifest(object):
             self.license = self.license_url = \
             self.url = self.status = \
             self.version = self.notes = ''
-        self.depends = []
         self.licenses = []
+        self.depends = []
         self.rosdeps = []
         self.exports = []
         self.platforms = []

--- a/src/rospkg/manifest.py
+++ b/src/rospkg/manifest.py
@@ -315,8 +315,8 @@ class Manifest(object):
     """
     __slots__ = [
         'description', 'brief',
-        'author', 'license', 'license_url', 'url',
-        'depends', 'rosdeps', 'platforms',
+        'author', 'license', 'licenses', 'license_url',
+        'url', 'depends', 'rosdeps', 'platforms',
         'exports', 'version',
         'status', 'notes',
         'unknown_tags', 'type', 'filename',
@@ -333,6 +333,7 @@ class Manifest(object):
             self.url = self.status = \
             self.version = self.notes = ''
         self.depends = []
+        self.licenses = []
         self.rosdeps = []
         self.exports = []
         self.platforms = []
@@ -397,6 +398,7 @@ def parse_manifest_file(dirpath, manifest_name, rospack=None):
         manifest.description = p.description
         manifest.author = ', '.join([('Maintainer: %s' % str(m)) for m in p.maintainers] + [str(a) for a in p.authors])
         manifest.license = ', '.join(p.licenses)
+        manifest.licenses = p.licenses
         if p.urls:
             manifest.url = str(p.urls[0])
         manifest.version = p.version

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -58,3 +58,11 @@ def test_get_manifest():
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
+
+
+def test_licenses():
+    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
+    manif = manager.get_manifest("foo")
+    assert(manif.license == "BSD, LGPL")
+    assert(len(manif.licenses) == 2)  # package.xml in 'foo' defines BSD and LGPL

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -60,7 +60,11 @@ def test_get_manifest():
 
 
 def test_licenses():
-    manager = rospkg.rospack.RosPack(ros_paths=[search_path])
-    manif = manager.get_manifest("foo")
-    assert(manif.license == "BSD, LGPL")
-    assert(len(manif.licenses) == 2)  # package.xml in 'foo' defines BSD and LGPL
+    rospack = rospkg.rospack.RosPack(ros_paths=[search_path]) 
+    licenses_list = ["BSD", "LGPL"]
+    licenses_str = ", ".join(licenses_list)
+    manif = rospack.get_manifest("foo")
+    print("DEBUG: manif.licenses={}".format(manif.licenses))
+    assert(manif.license == licenses_str)
+    for license in manif.licenses:
+        assert(license in licenses_list)

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -36,10 +36,10 @@ import os
 
 import rospkg
 
+search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
+
 
 def test_find_packages():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
-
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     # for backward compatibility a wet package which is not a metapackage is found when searching for MANIFEST_FILE
     assert(len(manager.list()) == 1)
@@ -54,14 +54,12 @@ def test_find_packages():
 
 
 def test_get_manifest():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
     manager = rospkg.rospack.ManifestManager(rospkg.common.MANIFEST_FILE, ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.type == "package")
 
 
 def test_licenses():
-    search_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'catkin_package_tests'))
     manager = rospkg.rospack.RosPack(ros_paths=[search_path])
     manif = manager.get_manifest("foo")
     assert(manif.license == "BSD, LGPL")

--- a/test/test_rospkg_catkin_packages.py
+++ b/test/test_rospkg_catkin_packages.py
@@ -60,11 +60,10 @@ def test_get_manifest():
 
 
 def test_licenses():
-    rospack = rospkg.rospack.RosPack(ros_paths=[search_path]) 
+    rospack = rospkg.rospack.RosPack(ros_paths=[search_path])
     licenses_list = ["BSD", "LGPL"]
-    licenses_str = ", ".join(licenses_list)
     manif = rospack.get_manifest("foo")
-    print("DEBUG: manif.licenses={}".format(manif.licenses))
-    assert(manif.license == licenses_str)
-    for license in manif.licenses:
-        assert(license in licenses_list)
+    assert(manif.license == ", ".join(licenses_list))
+    assert(len(manif.licenses) == 2)
+    for l in manif.licenses:
+        assert(l in licenses_list)


### PR DESCRIPTION
# Changes suggested

Add a `licenses` field to Manifest class (in addition to `license` field).

# Background

Although {manifest, package}.xml format allows to define separate `license` xml elements, rospkg handles multiple licenses as a single string joined by a comma, which is inconvenient depending on the consumers' usecase.

Pointed out at https://github.com/ros-infrastructure/rospkg/pull/133#discussion_r253230420

# Discussion
- If we want to maintain backward compatibility, `license` str field shouldn't change. So without making any change to it, this PR only adds a new field. This could cause a confusion.
  - One way to mitigate I thought was to print a deprecation warning for `license` field when it's called by a consumer. But because it looks like `license` is (and other fields are) intended to be accessed directly (without getter method/structure), I couldn't think of a way to do that.

# Dependency on other PRs/issues
None

# Test sample result
```
$ ipython
Python 2.7.12 (default, Nov 12 2018, 14:36:49)
Type "copyright", "credits" or "license" for more information.

IPython 2.4.1 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import rospkg
In [2]: rp = rospkg.RosPack()
In [4]: p = rp.get_manifest("rviz")
In [5]: p.license
Out[5]: 'BSD, Creative Commons'

In [6]: p.licenses
Out[6]: ['BSD', 'Creative Commons']
```

# Review items suggested
- [x] Requester provides reproducible commands and sample test result.
- [x] CI should pass.
- [ ] Code review.