### PR TITLE
os_detect: add support for NixOS

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -713,16 +713,16 @@ OS_MX = 'mx'
 OS_NEON = 'neon'
 OS_OPENEMBEDDED = 'openembedded'
 OS_OPENSUSE = 'opensuse'
-OS_TIZEN = 'tizen'
 OS_OPENSUSE13 = 'opensuse'
+OS_TIZEN = 'tizen'
 OS_OSX = 'osx'
 OS_QNX = 'qnx'
 OS_RHEL = 'rhel'
 OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
-OS_WINDOWS = 'windows'
 OS_CLEARLINUX = 'clearlinux'
 OS_NIXOS = 'nixos'
+OS_WINDOWS = 'windows'
 
 OsDetect.register_default(OS_ALPINE, FdoDetect("alpine"))
 OsDetect.register_default(OS_ARCH, Arch())

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -722,6 +722,7 @@ OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
 OS_WINDOWS = 'windows'
 OS_CLEARLINUX = 'clearlinux'
+OS_NIXOS = 'nixos'
 
 OsDetect.register_default(OS_ALPINE, FdoDetect("alpine"))
 OsDetect.register_default(OS_ARCH, Arch())
@@ -750,6 +751,7 @@ OsDetect.register_default(OS_RHEL, Rhel())
 OsDetect.register_default(OS_SLACKWARE, Slackware())
 OsDetect.register_default(OS_UBUNTU, LsbDetect("Ubuntu"))
 OsDetect.register_default(OS_CLEARLINUX, FdoDetect("clear-linux-os"))
+OsDetect.register_default(OS_NIXOS, FdoDetect("nixos"))
 OsDetect.register_default(OS_WINDOWS, Windows())
 
 


### PR DESCRIPTION
This is the first step in adding support for [Nix](https://nixos.org/) to ROS. The Nix package manager is often used with NixOS, but it runs on any Linux distribution as well as macOS. When packages are built, `/etc/os-release` is not available in the build sandbox, so `ROS_OS_OVERRIDE` has to be used anyway. In order to fit cleanly into the ROS infrastructure, I am pretending that Nix and NixOS have the traditional package manager and distribution relationship.

I am working on adding support for Nix to various ROS projects:
* https://github.com/lopsided98/rosdistro/tree/nixos-support
* https://github.com/lopsided98/rosdep/tree/nixos-support
* https://github.com/lopsided98/superflore/tree/nixos-support

I maintain a [Superflore generated nixpkgs overlay](https://github.com/lopsided98/nix-ros-overlay) and have successfully built over 3600 ROS packages on a [Hydra](https://nixos.org/hydra/) build server (not yet publicly accessible)