### PR TITLE
Add cosmic, disco, and eoan suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,7 +10,7 @@ Depends: python-argparse, python-rospkg-modules (>= 1.1.10)
 Depends3: python3-rospkg-modules (>= 1.1.10)
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -21,6 +21,6 @@ Conflicts: python-rospkg (<< 1.1.0)
 Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
-Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic jessie stretch buster
+Suite: trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
These are now live on the ROS bootstrap repository and future releases should be pushed to them as well.