### PR TITLE
add Python 3.7 and 3.8 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -200,10 +200,10 @@ class FdoDetect(OsDetector):
             if "VERSION" in self.release_info:
                 version = self.release_info["VERSION"]
                 # FDO style: works with Fedora, Debian, Suse.
-                if version.find("(") is not -1:
+                if '(' in version:
                     codename = version[version.find("(") + 1:version.find(")")]
                 # Ubuntu style
-                elif version.find(",") is not -1:
+                elif '"' in version:
                     codename = version[version.find(",") + 1:].lstrip(' ').split()[0]
                 # Indeterminate style
                 else:


### PR DESCRIPTION
Since Debian Buster uses Python 3.7 and Ubuntu Focal targets Python 3.8.