### PR TITLE
Always import distro on Python >= 3.8

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -37,10 +37,11 @@ from __future__ import print_function
 
 import codecs
 # to be removed after Ubuntu Xenial is out of support
-try:
-    import platform as distro
-except ImportError:
+import sys
+if sys.version_info >= (3, 8):
     import distro
+else:
+    import platform as distro
 import locale
 import os
 import platform

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -102,10 +102,11 @@ def test_LsbDetect():
 
     # test match
     # to be removed after Ubuntu Xenial is out of support
-    try:
-        import platform as distro
-    except ImportError:
+    import sys
+    if sys.version_info >= (3, 8):
         import distro
+    else:
+        import platform as distro
 
     distro.linux_distribution = mock.Mock()
     distro.linux_distribution.return_value = ('Ubuntu', '10.04', 'lucid')


### PR DESCRIPTION
Only the used functions of the platform module where deprecated, so test
for the Python version to get the right module.