### PR TITLE
Use /bin/sh instead of python 2

### DIFF
--- a/test/os_detect/osx/sw_vers
+++ b/test/os_detect/osx/sw_vers
@@ -1,3 +1,2 @@
-#!/usr/bin/env python
-import sys
-sys.stdout.write("10.6.5\n")
+#!/bin/sh
+echo "10.6.5"

--- a/test/os_detect/osx/sw_vers_bad
+++ b/test/os_detect/osx/sw_vers_bad
@@ -1,3 +1,2 @@
-#!/usr/bin/env python
-import sys
-sys.stdout.write("10\n")
+#!/bin/sh
+echo "10"

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -163,6 +163,10 @@ def test_tripwire_osx():
 
 
 def test_osx():
+    if 'posix' != os.name:
+        from unittest.case import SkipTest
+        raise SkipTest('Test requires POSIX platform, not "{}"'.format(os.name))
+
     from rospkg.os_detect import OSX, _osx_codename, OsNotDetected
     test_dir = os.path.join(get_test_dir(), 'osx')
     detect = OSX(os.path.join(test_dir, "sw_vers"))


### PR DESCRIPTION
This fixes a test failure in `test.test_rospkg_os_detect.test_osx` on systems that don't have python 2 installed by using `sh` instead of `python`.

https://github.com/ros-infrastructure/rospkg/pull/182#issuecomment-566835331