### PR TITLE
Case insensitive LSB name checking

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -146,10 +146,10 @@ class LsbDetect(OsDetector):
             self.lsb_info = None
 
     def is_os(self):
+        if self.lsb_info is None:
+            return False
         # Work around platform returning 'Ubuntu' and distro returning 'ubuntu'
-        name_is_same = self.lsb_info[0].lower() == self.lsb_name.lower()
-
-        return self.lsb_info is not None and name_is_same
+        return self.lsb_info[0].lower() == self.lsb_name.lower()
 
     def get_version(self):
         if self.is_os():

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -146,7 +146,10 @@ class LsbDetect(OsDetector):
             self.lsb_info = None
 
     def is_os(self):
-        return self.lsb_info is not None and self.lsb_info[0] == self.lsb_name
+        # Work around platform returning 'Ubuntu' and distro returning 'ubuntu'
+        name_is_same = self.lsb_info[0].lower() == self.lsb_name.lower()
+
+        return self.lsb_info is not None and name_is_same
 
     def get_version(self):
         if self.is_os():


### PR DESCRIPTION
This PR [fixes a bug that breaks rosdep](https://github.com/ros-infrastructure/rospkg/pull/182#issuecomment-566835331) when using Python 3.8 on Ubuntu. 

`platform.linux_distribution(full_distribution_name=0)` returns `Ubuntu` while `distro.linux_distribution(full_distrition_name=0)` returns `ubuntu`. This causes rosdep to fail to detect the os version on ubuntu when using python 3.8. This does not appear to be a bug in `distro`, [which warns the data returned may differ](https://github.com/nir0s/distro/blob/cdfe85d15bd366820db6a1cfdc6cf9a0a5de7e37/distro.py#L109-L120).

```
Python 3.8.0 (default, Oct 28 2019, 16:14:01) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import distro
>>> distro.linux_distribution()
('Ubuntu', '18.04', 'bionic')
>>> distro.linux_distribution(full_distribution_name=0)
('ubuntu', '18.04', 'bionic')
>>> 
```

```
Python 3.7.5 (default, Nov  7 2019, 10:50:52) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.linux_distribution()
__main__:1: DeprecationWarning: dist() and linux_distribution() functions are deprecated in Python 3.5
('Ubuntu', '18.04', 'bionic')
>>> platform.linux_distribution(full_distribution_name=0)
('Ubuntu', '18.04', 'bionic')
```

