### PR TITLE
Add OS detection for Sailfish OS

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -729,6 +729,7 @@ OS_OPENEMBEDDED = 'openembedded'
 OS_OPENSUSE = 'opensuse'
 OS_OPENSUSE13 = 'opensuse'
 OS_TIZEN = 'tizen'
+OS_SAILFISHOS = 'sailfishos'
 OS_OSX = 'osx'
 OS_QNX = 'qnx'
 OS_RHEL = 'rhel'
@@ -761,6 +762,7 @@ OsDetect.register_default(OS_OPENSUSE13, OpenSuse(brand_file='/etc/SUSE-brand', 
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-tumbleweed"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
 OsDetect.register_default(OS_TIZEN, FdoDetect("tizen"))
+OsDetect.register_default(OS_SAILFISHOS, FdoDetect("sailfishos"))
 OsDetect.register_default(OS_OSX, OSX())
 OsDetect.register_default(OS_QNX, QNX())
 OsDetect.register_default(OS_RHEL, Rhel())


### PR DESCRIPTION
This adds os detection for [Sailfish OS](https://sailfishos.org). It's a one of the true Linux mobiles OS platforms like postmarketOS and has the same predecessor as Tizen.