### PR TITLE
cElementTree has been deprecated since Python 3.3 and removed in Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -31,8 +31,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import sys
 from threading import Lock
-from xml.etree.cElementTree import ElementTree
+
+if sys.version_info >= (3, 3):
+    from xml.etree.ElementTree import ElementTree
+else:
+    from xml.etree.cElementTree import ElementTree
 
 from .common import MANIFEST_FILE, PACKAGE_FILE, ResourceNotFound, STACK_FILE
 from .environment import get_ros_paths

--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -31,13 +31,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import sys
 from threading import Lock
 
-if sys.version_info >= (3, 3):
-    from xml.etree.ElementTree import ElementTree
-else:
+try:
     from xml.etree.cElementTree import ElementTree
+except ImportError:
+    from xml.etree.ElementTree import ElementTree
 
 from .common import MANIFEST_FILE, PACKAGE_FILE, ResourceNotFound, STACK_FILE
 from .environment import get_ros_paths


### PR DESCRIPTION
Fixes Fedora builds for Python 3.9 : https://bugzilla.redhat.com/show_bug.cgi?id=1817942