### PR TITLE
Fix deprecation warning regarding invalid escape sequences.

### DIFF
--- a/src/rospkg/distro.py
+++ b/src/rospkg/distro.py
@@ -282,7 +282,7 @@ def _distro_version(version_val):
     # check for no keyword sub
     if version_val == '$Revision$':
         return 0
-    m = re.search('\$Revision:\s*([0-9]*)\s*\$', version_val)
+    m = re.search(r'\$Revision:\s*([0-9]*)\s*\$', version_val)
     if m is not None:
         version_val = 'r' + m.group(1)
 


### PR DESCRIPTION
Deprecation warning due to invalid escape sequences in Python 3.7. This can be fixed using raw strings or escaping the sequences. This can be reproduced by trying to compile the file with warnings on.

```
find . -iname '*.py' | grep -v example | xargs -I{} python3.8 -Wall -m py_compile {}
./src/rospkg/distro.py:285: DeprecationWarning: invalid escape sequence \$
  m = re.search('\$Revision:\s*([0-9]*)\s*\$', version_val)
```