### PR TITLE
Revert "Ensure 'distro' dependency is absent for python < 3.8"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,14 @@ import sys
 
 from setuptools import setup
 
+install_requires = ['catkin_pkg', 'PyYAML']
+
+if (
+    'SKIP_PYTHON_MODULES' not in os.environ and
+    'SKIP_PYTHON_SCRIPTS' not in os.environ
+):
+    install_requires.append('distro')
+
 kwargs = {
     'name': 'rospkg',
     # same version as in:
@@ -16,7 +24,7 @@ kwargs = {
     'entry_points': {
         'console_scripts': ['rosversion=rospkg.rosversion:main'],
     },
-    'install_requires': ['catkin_pkg', 'distro', 'PyYAML'],
+    'install_requires': install_requires,
     'author': 'Ken Conley',
     'author_email': 'kwc@willowgarage.com',
     'url': 'http://wiki.ros.org/rospkg',
@@ -33,14 +41,6 @@ kwargs = {
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     kwargs['install_requires'].append('argparse')
-
-if (
-    sys.version_info[0] < 3 or
-    (sys.version_info[0] == 3 and sys.version_info[1] < 8) or
-    'SKIP_PYTHON_MODULES' in os.environ or
-    'SKIP_PYTHON_SCRIPTS' in os.environ
-):
-    kwargs['install_requires'].remove('distro')
 
 if 'SKIP_PYTHON_MODULES' in os.environ:
     kwargs['packages'] = []


### PR DESCRIPTION
Reverts ros-infrastructure/rospkg#196

Wheels generated and uploaded to PyPI with Python < 3.8 don't contain the `distro` dependency.