### PR TITLE
Add Python2-Depends-Name option for stdeb 0.9.0.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -12,6 +12,7 @@ Conflicts: python3-rospkg
 Conflicts3: python-rospkg
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
@@ -24,5 +25,6 @@ Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
This option is required to make releases from Ubuntu Focal and other
distributions where the Python 2 package name is python2 rather than
python.

This option requires the use of stdeb 0.9.0 or later. https://github.com/astraw/stdeb/pull/156

https://github.com/ros-infrastructure/catkin_pkg/pull/288 is a parallel change for catkin-pkg.

Python 2 packages from the recent 1.2.7 release are currently uninstallable as a result of this option being unset.