### PR TITLE
Use GitHub Actions for rospkg CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: rospkg-ci
 
 on:
   push:
-    branches: ['master']
+    branches: [master]
   pull_request:
     branches: ['*']
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install nose coverage
+          python -m pip install nose coverage mock
           python setup.py build develop
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: rospkg-ci
+
+on: [push, pull_request]
+
+jobs:
+    build:
+      strategy:
+        matrix:
+          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+          exclude:
+          - os: ubuntu-16.04
+            python: 3.6
+          - os: ubuntu-16.04
+            python: 3.7
+          - os: ubuntu-16.04
+            python: 3.8
+          - os: ubuntu-16.04
+            python: 3.9
+          - os: ubuntu-18.04
+            python: 3.5
+          - os: ubuntu-18.04
+            python: 3.6
+          - os: ubuntu-20.04
+            python: 2.7
+          - os: ubuntu-20.04
+            python: 3.5
+          - os: ubuntu-20.04
+            python: 3.6
+          - os: ubuntu-20.04
+            python: 3.7
+          - os: macos-latest
+            python: 3.5
+          - os: macos-latest
+            python: 3.6
+      name: rospkg tests
+      runs-on: ${{matrix.os}}
+
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install nose coverage
+          python setup.py build develop
+      - name: Run tests
+        run: |
+          python -m nose --with-coverage --cover-package=rospkg --with-xunit test
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: rospkg-ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['*']
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,5 +57,3 @@ jobs:
       - name: Run tests
         run: |
           python -m nose --with-coverage --cover-package=rospkg --with-xunit test
-
-

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,9 @@ jobs:
           python-version: ${{matrix.python}}
       - name: Install dependencies
         run: |
+          if test ${{matrix.python}} = 2.7; then
+            python -m pip install pyparsing==2.4.7
+          fi
           python -m pip install --upgrade pip setuptools
           python -m pip install nose coverage mock
           python setup.py build develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 python:
-  - "2.7"
   - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "3.8"
 # command to install dependencies
 install:
 # develop seems to be required by travis since 02/2013


### PR DESCRIPTION
With the exception of 3.4 which is not supported by the setup-python
action so we leave that one set up in Travis for the (likely brief)
remainder of python 3.4 support.

This is mostly a port of the travis handling. I did change `nosetests` to `python -m nose`