### PR TITLE
Fix CentOS 8.3 detection

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -474,9 +474,12 @@ class Centos(OsDetector):
             os_list = read_issue(self._release_file)
             idx = os_list.index('release')
             matches = [x for x in os_list if x[0] == '(']
-            codename = matches[0][1:]
-            if codename[-1] == ')':
-                codename = codename[:-1]
+            if matches:
+                codename = matches[0][1:]
+                if codename[-1] == ')':
+                    codename = codename[:-1]
+            else:
+                codename = os_list[-1]
             return codename.lower()
         raise OsNotDetected('called in incorrect OS')
 

--- a/test/os_detect/centos/issue
+++ b/test/os_detect/centos/issue
@@ -1,0 +1,3 @@
+\S
+Kernel \r on an \m
+

--- a/test/os_detect/centos/redhat-release-8.2
+++ b/test/os_detect/centos/redhat-release-8.2
@@ -1,0 +1,1 @@
+CentOS Linux release 8.2.2004 (Core)

--- a/test/os_detect/centos/redhat-release-8.3
+++ b/test/os_detect/centos/redhat-release-8.3
@@ -1,0 +1,1 @@
+CentOS Linux release 8.3.2011

--- a/test/os_detect/rhel/redhat-release-ootpa
+++ b/test/os_detect/rhel/redhat-release-ootpa
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux release 8.3 (Ootpa)

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -439,6 +439,11 @@ def test_redhat():
     assert detect.get_version() == '4'
     assert detect.get_codename() == 'nahant'
 
+    detect = Rhel(os.path.join(test_dir, "redhat-release-ootpa"))
+    assert detect.is_os()
+    assert detect.get_version() == '8.3'
+    assert detect.get_codename() == 'ootpa'
+
     # test freely
     detect = Rhel()
     if not detect.is_os():
@@ -554,6 +559,42 @@ def test_cygwin():
         detect = Cygwin()
         assert detect.get_codename() == ''
     test()
+
+
+def test_tripwire_centos():
+    from rospkg.os_detect import OsDetect
+    os_detect = OsDetect()
+    os_detect.get_detector('centos')
+
+
+def test_centos():
+    from rospkg.os_detect import Centos, OsNotDetected
+    test_dir = os.path.join(get_test_dir(), 'centos')
+
+    # go through several test files
+    detect = Centos(os.path.join(test_dir, "redhat-release-8.2"))
+    assert detect.is_os()
+    assert detect.get_version() == '8.2.2004'
+    assert detect.get_codename() == 'core'
+
+    detect = Centos(os.path.join(test_dir, "redhat-release-8.3"))
+    assert detect.is_os()
+    assert detect.get_version() == '8.3.2011'
+    assert detect.get_codename() == '8.3.2011'
+
+    # test freely
+    detect = Centos()
+    if not detect.is_os():
+        try:
+            detect.get_version()
+            assert False
+        except OsNotDetected:
+            pass
+        try:
+            detect.get_codename()
+            assert False
+        except OsNotDetected:
+            pass
 
 
 def test_OsDetect():


### PR DESCRIPTION
It seems that CentOS 8.3 dropped the codename part of the `redhat-release` file entirely. Even before this change, the codename was essentially a placeholder - rosdep is configured to use the version number (major/minor only). Since there isn't anything in parenthesis in the file, just return the last "word" on the line, which should be the version number.

Also mimic the RHEL tests for CentOS to verify this change, and add a RHEL 8 release file to the existing RHEL tests.