### PR TITLE
Switch RedHat-likes to FdoDetect, add some RHEL clones

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -278,69 +278,6 @@ class OpenSuse(OsDetector):
         raise OsNotDetected('called in incorrect OS')
 
 
-class Fedora(OsDetector):
-    """
-    Detect Fedora OS.
-    """
-    def __init__(self, release_file="/etc/redhat-release", issue_file="/etc/issue"):
-        self._release_file = release_file
-        self._issue_file = issue_file
-
-    def is_os(self):
-        os_list = read_issue(self._release_file)
-        return os_list and os_list[0] == "Fedora"
-
-    def get_version(self):
-        if self.is_os():
-            os_list = read_issue(self._issue_file)
-            idx = os_list.index('release')
-            if idx > 0:
-                return os_list[idx + 1]
-        raise OsNotDetected('cannot get version on this OS')
-
-    def get_codename(self):
-        if self.is_os():
-            os_list = read_issue(self._release_file)
-            idx = os_list.index('release')
-            matches = [x for x in os_list if x[0] == '(']
-            codename = matches[0][1:]
-            if codename[-1] == ')':
-                codename = codename[:-1]
-            return codename.lower()
-        raise OsNotDetected('called in incorrect OS')
-
-
-class Rhel(Fedora):
-    """
-    Detect Redhat OS.
-    """
-    def __init__(self, release_file="/etc/redhat-release"):
-        self._release_file = release_file
-
-    def is_os(self):
-        os_list = read_issue(self._release_file)
-        return os_list and os_list[:3] == ['Red', 'Hat', 'Enterprise']
-
-    def get_version(self):
-        if self.is_os():
-            os_list = read_issue(self._release_file)
-            idx = os_list.index('release')
-            return os_list[idx + 1]
-        raise OsNotDetected('called in incorrect OS')
-
-    def get_codename(self):
-        # taroon, nahant, tikanga, santiago, pensacola
-        if self.is_os():
-            os_list = read_issue(self._release_file)
-            idx = os_list.index('release')
-            matches = [x for x in os_list if x[0] == '(']
-            codename = matches[0][1:]
-            if codename[-1] == ')':
-                codename = codename[:-1]
-            return codename.lower()
-        raise OsNotDetected('called in incorrect OS')
-
-
 # Source: https://en.wikipedia.org/wiki/MacOS#Versions
 _osx_codename_map = {
     4: 'tiger',
@@ -449,51 +386,6 @@ class Manjaro(Arch):
     """
     def __init__(self, release_file='/etc/manjaro-release'):
         super(Manjaro, self).__init__(release_file)
-
-
-class Centos(OsDetector):
-    """
-    Detect CentOS.
-    """
-    def __init__(self, release_file='/etc/redhat-release'):
-        self._release_file = release_file
-
-    def is_os(self):
-        os_list = read_issue(self._release_file)
-        return os_list and os_list[0] == 'CentOS'
-
-    def get_version(self):
-        if self.is_os():
-            os_list = read_issue(self._release_file)
-            idx = os_list.index('release')
-            return os_list[idx + 1]
-        raise OsNotDetected('called in incorrect OS')
-
-    def get_codename(self):
-        if self.is_os():
-            os_list = read_issue(self._release_file)
-            idx = os_list.index('release')
-            matches = [x for x in os_list if x[0] == '(']
-            if matches:
-                codename = matches[0][1:]
-                if codename[-1] == ')':
-                    codename = codename[:-1]
-            else:
-                codename = os_list[-1]
-            return codename.lower()
-        raise OsNotDetected('called in incorrect OS')
-
-
-class Euleros(Centos):
-    """
-    Detect Euleros.
-    """
-    def __init__(self, release_file='/etc/euleros-release'):
-        super(Euleros, self).__init__(release_file)
-
-    def is_os(self):
-        os_list = read_issue(self._release_file)
-        return os_list and os_list[0] == 'EulerOS'
 
 
 class Cygwin(OsDetector):
@@ -724,7 +616,9 @@ class OsDetect:
         return self._os_codename
 
 
+OS_ALMALINUX = 'almalinux'
 OS_ALPINE = 'alpine'
+OS_AMAZON = 'amazon'
 OS_ARCH = 'arch'
 OS_BUILDROOT = 'buildroot'
 OS_MANJARO = 'manjaro'
@@ -745,12 +639,14 @@ OS_NEON = 'neon'
 OS_OPENEMBEDDED = 'openembedded'
 OS_OPENSUSE = 'opensuse'
 OS_OPENSUSE13 = 'opensuse'
+OS_ORACLE = 'oracle'
 OS_TIZEN = 'tizen'
 OS_SAILFISHOS = 'sailfishos'
 OS_OSX = 'osx'
 OS_POP = 'pop'
 OS_QNX = 'qnx'
 OS_RHEL = 'rhel'
+OS_ROCKY = 'rocky'
 OS_SLACKWARE = 'slackware'
 OS_UBUNTU = 'ubuntu'
 OS_CLEARLINUX = 'clearlinux'
@@ -758,12 +654,14 @@ OS_NIXOS = 'nixos'
 OS_WINDOWS = 'windows'
 OS_ZORIN =  'zorin'
 
+OsDetect.register_default(OS_ALMALINUX, FdoDetect("almalinux"))
 OsDetect.register_default(OS_ALPINE, FdoDetect("alpine"))
+OsDetect.register_default(OS_AMAZON, FdoDetect("amzn"))
 OsDetect.register_default(OS_ARCH, Arch())
 OsDetect.register_default(OS_BUILDROOT, FdoDetect("buildroot"))
 OsDetect.register_default(OS_MANJARO, Manjaro())
-OsDetect.register_default(OS_CENTOS, Centos())
-OsDetect.register_default(OS_EULEROS, Euleros())
+OsDetect.register_default(OS_CENTOS, FdoDetect("centos"))
+OsDetect.register_default(OS_EULEROS, FdoDetect("euleros"))
 OsDetect.register_default(OS_CYGWIN, Cygwin())
 OsDetect.register_default(OS_DEBIAN, Debian())
 OsDetect.register_default(OS_ELEMENTARY, LsbDetect("elementary"))
@@ -781,12 +679,14 @@ OsDetect.register_default(OS_OPENSUSE, OpenSuse())
 OsDetect.register_default(OS_OPENSUSE13, OpenSuse(brand_file='/etc/SUSE-brand', release_file=None))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-tumbleweed"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
+OsDetect.register_default(OS_ORACLE, FdoDetect("ol"))
 OsDetect.register_default(OS_TIZEN, FdoDetect("tizen"))
 OsDetect.register_default(OS_SAILFISHOS, FdoDetect("sailfishos"))
 OsDetect.register_default(OS_OSX, OSX())
 OsDetect.register_default(OS_POP, LsbDetect("Pop"))
 OsDetect.register_default(OS_QNX, QNX())
-OsDetect.register_default(OS_RHEL, Rhel())
+OsDetect.register_default(OS_RHEL, FdoDetect("rhel"))
+OsDetect.register_default(OS_ROCKY, FdoDetect("rocky"))
 OsDetect.register_default(OS_SLACKWARE, Slackware())
 OsDetect.register_default(OS_UBUNTU, LsbDetect("Ubuntu"))
 OsDetect.register_default(OS_CLEARLINUX, FdoDetect("clear-linux-os"))

--- a/test/os_detect/centos/issue
+++ b/test/os_detect/centos/issue
@@ -1,3 +1,0 @@
-\S
-Kernel \r on an \m
-

--- a/test/os_detect/centos/redhat-release-8.2
+++ b/test/os_detect/centos/redhat-release-8.2
@@ -1,1 +1,0 @@
-CentOS Linux release 8.2.2004 (Core)

--- a/test/os_detect/centos/redhat-release-8.3
+++ b/test/os_detect/centos/redhat-release-8.3
@@ -1,1 +1,0 @@
-CentOS Linux release 8.3.2011

--- a/test/os_detect/fedora/issue
+++ b/test/os_detect/fedora/issue
@@ -1,1 +1,0 @@
-Fedora Core release 1 (Yarrow)

--- a/test/os_detect/fedora/redhat-release
+++ b/test/os_detect/fedora/redhat-release
@@ -1,1 +1,0 @@
-Fedora Core release 5 (Bordeaux)

--- a/test/os_detect/rhel/redhat-release
+++ b/test/os_detect/rhel/redhat-release
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux ES release 3 (Taroon Update 4)

--- a/test/os_detect/rhel/redhat-release-nahant
+++ b/test/os_detect/rhel/redhat-release-nahant
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux AS release 4 (Nahant Update 4)

--- a/test/os_detect/rhel/redhat-release-ootpa
+++ b/test/os_detect/rhel/redhat-release-ootpa
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux release 8.3 (Ootpa)

--- a/test/os_detect/rhel/redhat-release-tikanga
+++ b/test/os_detect/rhel/redhat-release-tikanga
@@ -1,1 +1,0 @@
-Red Hat Enterprise Linux Server release 5 (Tikanga)

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -360,25 +360,6 @@ def get_test_dir():
                                         'os_detect'))
 
 
-def test_fedora():
-    from rospkg.os_detect import Fedora, OsNotDetected
-    test_dir = os.path.join(get_test_dir(), 'fedora')
-    release_file, issue_file = [os.path.join(test_dir, x) for
-                                x in ["redhat-release", "issue"]]
-    detect = Fedora(release_file, issue_file)
-    assert detect.is_os()
-    assert detect.get_version() == '1'
-    assert detect.get_codename() == 'bordeaux', detect.get_codename()
-
-    detect = Fedora()
-    if not detect.is_os():
-        try:
-            detect.get_version()
-            assert False
-        except OsNotDetected:
-            pass
-
-
 def test_read_issue():
     from rospkg.os_detect import read_issue
     assert read_issue('/fake/file') is None
@@ -417,46 +398,6 @@ def test_tripwire_rhel():
     from rospkg.os_detect import OsDetect
     os_detect = OsDetect()
     os_detect.get_detector('rhel')
-
-
-def test_redhat():
-    from rospkg.os_detect import Rhel, OsNotDetected
-    test_dir = os.path.join(get_test_dir(), 'rhel')
-
-    # go through several test files
-    detect = Rhel(os.path.join(test_dir, "redhat-release"))
-    assert detect.is_os()
-    assert detect.get_version() == '3'
-    assert detect.get_codename() == 'taroon'
-
-    detect = Rhel(os.path.join(test_dir, "redhat-release-tikanga"))
-    assert detect.is_os()
-    assert detect.get_version() == '5'
-    assert detect.get_codename() == 'tikanga'
-
-    detect = Rhel(os.path.join(test_dir, "redhat-release-nahant"))
-    assert detect.is_os()
-    assert detect.get_version() == '4'
-    assert detect.get_codename() == 'nahant'
-
-    detect = Rhel(os.path.join(test_dir, "redhat-release-ootpa"))
-    assert detect.is_os()
-    assert detect.get_version() == '8.3'
-    assert detect.get_codename() == 'ootpa'
-
-    # test freely
-    detect = Rhel()
-    if not detect.is_os():
-        try:
-            detect.get_version()
-            assert False
-        except OsNotDetected:
-            pass
-        try:
-            detect.get_codename()
-            assert False
-        except OsNotDetected:
-            pass
 
 
 def test_tripwire_slackware():
@@ -565,36 +506,6 @@ def test_tripwire_centos():
     from rospkg.os_detect import OsDetect
     os_detect = OsDetect()
     os_detect.get_detector('centos')
-
-
-def test_centos():
-    from rospkg.os_detect import Centos, OsNotDetected
-    test_dir = os.path.join(get_test_dir(), 'centos')
-
-    # go through several test files
-    detect = Centos(os.path.join(test_dir, "redhat-release-8.2"))
-    assert detect.is_os()
-    assert detect.get_version() == '8.2.2004'
-    assert detect.get_codename() == 'core'
-
-    detect = Centos(os.path.join(test_dir, "redhat-release-8.3"))
-    assert detect.is_os()
-    assert detect.get_version() == '8.3.2011'
-    assert detect.get_codename() == '8.3.2011'
-
-    # test freely
-    detect = Centos()
-    if not detect.is_os():
-        try:
-            detect.get_version()
-            assert False
-        except OsNotDetected:
-            pass
-        try:
-            detect.get_codename()
-            assert False
-        except OsNotDetected:
-            pass
 
 
 def test_OsDetect():


### PR DESCRIPTION
Switch all remaining RedHat distributions to use FdoDetect instead of the custom `/etc/redhat-release` detection.

Also add support for AlmaLinux, Amazon Linux, Oracle Linux, and Rocky Linux.

Results of running `python3 -m rospkg.os_detect` on each of these platforms:
* AlmaLinux 8:
  ```
  OS Name:     almalinux
  OS Version:  8.3
  OS Codename: purple manul
  ```
* Amazon Linux 2:
  ```
  OS Name:     amazon
  OS Version:  2
  OS Codename: 2
  ```
* CentOS 7:
  ```
  OS Name:     centos
  OS Version:  7
  OS Codename: core
  ```
* CentOS 8:
  ```
  OS Name:     centos
  OS Version:  8
  OS Codename: 8
  ```
* EulerOS:
  ```
  OS Name:     euleros
  OS Version:  2.0
  OS Codename: sp3
  ```
* Oracle Linux 8.3:
  ```
  OS Name:     oracle
  OS Version:  8.3
  OS Codename: 8.3
  ```
* RHEL 7:
  ```
  OS Name:     rhel
  OS Version:  7.6
  OS Codename: maipo
  ```
* RHEL 8:
  ```
  OS Name:     rhel
  OS Version:  8.2
  OS Codename: ootpa
  ```
* Rocky Linux
  ```
  OS Name:     rocky
  OS Version:  8
  OS Codename: 8
  ```