### PR TITLE
ManifestManager.list() should return a list

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -194,7 +194,7 @@ class ManifestManager(object):
         :returns: complete list of package names in ROS environment, ``[str]``
         """
         self._update_location_cache()
-        return self._location_cache.keys()
+        return list(self._location_cache.keys())
 
     def get_path(self, name):
         """


### PR DESCRIPTION
In python3 this is returning a "dict_keys", that for example broke code like this:

```python3
self.allnames = sorted(list(set(rospack.list() + rosstack.list()))) 
```

because the `+` operator isn't supported by `dict_keys`.

See [this](https://github.com/ros-visualization/rqt_dep/issues/15#issuecomment-819361754) and [this](https://github.com/ros-visualization/rqt_dep/issues/15#issuecomment-819527264) comments.
Downstream packages can also fix this directly, but it would be better if the `list()` method actually returned a python `list`.