### PR TITLE
Add Conda OS detection.

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -242,12 +242,14 @@ class OpenEmbedded(OsDetector):
         raise OsNotDetected('called in incorrect OS')
 
 
-class RoboStack(OsDetector):
+class Conda(OsDetector):
     """
-    Detect RoboStack.
+    Detect Conda.
     """
     def is_os(self):
-        return "ROS_OS_OVERRIDE" in os.environ and os.environ["ROS_OS_OVERRIDE"].startswith("robostack")
+        return "ROS_OS_OVERRIDE" in os.environ and
+            (os.environ["ROS_OS_OVERRIDE"].lower().startswith("robostack") or
+             os.environ["ROS_OS_OVERRIDE"].lower().startswith("conda"))
 
     def get_version(self):
         if self.is_os():
@@ -663,7 +665,7 @@ OS_OPENEMBEDDED = 'openembedded'
 OS_OPENSUSE = 'opensuse'
 OS_OPENSUSE13 = 'opensuse'
 OS_ORACLE = 'oracle'
-OS_ROBOSTACK = 'robostack'
+OS_CONDA = 'conda'
 OS_TIZEN = 'tizen'
 OS_SAILFISHOS = 'sailfishos'
 OS_OSX = 'osx'
@@ -705,7 +707,7 @@ OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-tumbleweed"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-leap"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
 OsDetect.register_default(OS_ORACLE, FdoDetect("ol"))
-OsDetect.register_default(OS_ROBOSTACK, RoboStack())
+OsDetect.register_default(OS_CONDA, Conda())
 OsDetect.register_default(OS_TIZEN, FdoDetect("tizen"))
 OsDetect.register_default(OS_SAILFISHOS, FdoDetect("sailfishos"))
 OsDetect.register_default(OS_OSX, OSX())

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -242,6 +242,24 @@ class OpenEmbedded(OsDetector):
         raise OsNotDetected('called in incorrect OS')
 
 
+class RoboStack(OsDetector):
+    """
+    Detect RoboStack.
+    """
+    def is_os(self):
+        return "ROS_OS_OVERRIDE" in os.environ and os.environ["ROS_OS_OVERRIDE"].startswith("robostack")
+
+    def get_version(self):
+        if self.is_os():
+            return ""
+        raise OsNotDetected('called in incorrect OS')
+
+    def get_codename(self):
+        if self.is_os():
+            return ""
+        raise OsNotDetected('called in incorrect OS')
+
+
 class OpenSuse(OsDetector):
     """
     Detect OpenSuse OS.
@@ -645,6 +663,7 @@ OS_OPENEMBEDDED = 'openembedded'
 OS_OPENSUSE = 'opensuse'
 OS_OPENSUSE13 = 'opensuse'
 OS_ORACLE = 'oracle'
+OS_ROBOSTACK = 'robostack'
 OS_TIZEN = 'tizen'
 OS_SAILFISHOS = 'sailfishos'
 OS_OSX = 'osx'
@@ -686,6 +705,7 @@ OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-tumbleweed"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-leap"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
 OsDetect.register_default(OS_ORACLE, FdoDetect("ol"))
+OsDetect.register_default(OS_ROBOSTACK, RoboStack())
 OsDetect.register_default(OS_TIZEN, FdoDetect("tizen"))
 OsDetect.register_default(OS_SAILFISHOS, FdoDetect("sailfishos"))
 OsDetect.register_default(OS_OSX, OSX())


### PR DESCRIPTION
Hi there,
We are currently adding `rosdep` functionality to the [RoboStack](https://github.com/RoboStack/ros-noetic) project which builds ROS binaries with Conda. The first step towards this aim is adding an `OsDetector` here. Locally, we already have a working version of `rosdep` that makes use of the new RoboStack OsDetector, and would like to merge as many changes as possible upstream. See https://github.com/RoboStack/ros-noetic/issues/41 for more information

/cc @wolfv @traversaro