### PR TITLE
Drop support for EOL Ubuntu distros

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,33 +10,13 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
-          python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+          os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
+          python: [2.7, 3.7, 3.8, 3.9]
           exclude:
-          - os: ubuntu-16.04
-            python: 3.6
-          - os: ubuntu-16.04
-            python: 3.7
-          - os: ubuntu-16.04
-            python: 3.8
-          - os: ubuntu-16.04
-            python: 3.9
-          - os: ubuntu-18.04
-            python: 3.5
-          - os: ubuntu-18.04
-            python: 3.6
           - os: ubuntu-20.04
             python: 2.7
           - os: ubuntu-20.04
-            python: 3.5
-          - os: ubuntu-20.04
-            python: 3.6
-          - os: ubuntu-20.04
             python: 3.7
-          - os: macos-latest
-            python: 3.5
-          - os: macos-latest
-            python: 3.6
       name: rospkg tests
       runs-on: ${{matrix.os}}
 

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,8 +10,8 @@ Depends: python-argparse, python-rospkg-modules (>= 1.3.0)
 Depends3: python3-rospkg-modules (>= 1.3.0)
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic jessie stretch buster
+Suite3: bionic focal jessie stretch buster
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -23,8 +23,8 @@ Conflicts: python-rospkg (<< 1.1.0)
 Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
-Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite: bionic jessie stretch buster
+Suite3: bionic focal jessie stretch buster
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
https://wiki.ubuntu.com/Releases#List_of_releases

- Xenial:  Apr 2021
- Yakkety: Jul 2017
- Zesty:   Jan 2019
- Artful:  Jul 2018
- Cosmic:  Oct 2018
- Disco:   Apr 2019
- Eoan:    Oct 2019