### PR TITLE
fix: Add macOS monterey to os_detect

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -292,7 +292,8 @@ _osx_codename_map = {
  '10.13': 'high sierra',
  '10.14': 'mojave',
  '10.15': 'catalina',
- '11': 'big sur'
+ '11': 'big sur',
+ '12': 'monterey'
 }
 
 


### PR DESCRIPTION
Similar issue https://github.com/ros-infrastructure/rosdep/issues/615
`rosdep update` is failing on macOS monterey