### PR TITLE
fix test for riscv machines (64 and 32 bits)

### DIFF
--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -391,7 +391,7 @@ def test_OsDetector():
 def test_tripwire_uname_get_machine():
     from rospkg.os_detect import uname_get_machine
     retval = uname_get_machine()
-    assert retval in [None, 'aarch64', 'armv7l', 'armv8l', 'i386', 'i686', 'ppc', 'ppc64', 'ppc64le', 's390', 's390x', 'x86_64']
+    assert retval in [None, 'aarch64', 'armv7l', 'armv8l', 'i386', 'i686', 'ppc', 'ppc64', 'ppc64le', 'riscv32', 'riscv64', 's390', 's390x', 'x86_64']
 
 
 def test_tripwire_rhel():


### PR DESCRIPTION
Hi, there.

I am trying to build ROS on Gentoo for riscv natively, specically on a Sifive Unmatch board. As riscv is an emerging arch, I guess soon others may also want to build ros packages natively on riscv. It would be a good addition to make this test pass.