### PR TITLE
Update release distributions.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -10,8 +10,8 @@ Depends: python-argparse, python-rospkg-modules (>= 1.3.0)
 Depends3: python3-rospkg-modules (>= 1.3.0)
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
-Suite: bionic jessie stretch buster
-Suite3: bionic focal jessie stretch buster
+Suite: bionic buster
+Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -23,8 +23,8 @@ Conflicts: python-rospkg (<< 1.1.0)
 Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
-Suite: bionic jessie stretch buster
-Suite3: bionic focal jessie stretch buster
+Suite: bionic buster
+Suite3: bionic focal jammy buster bullseye
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
* Drop Debian Jessie and Debian Stretch which are no longer supported upstream
* Add Debian Bullseye for Python 3.
* Add Ubuntu Jammy for Python 3