### PR TITLE
Refactor CI platforms.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,13 @@ jobs:
     build:
       strategy:
         matrix:
-          os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
-          python: [2.7, 3.7, 3.8, 3.9]
-          exclude:
-          - os: ubuntu-20.04
+          os: [ubuntu-latest, macos-latest]
+          python: [3.7, 3.8, 3.9]
+          include:
+          - os: ubuntu-18.04
             python: 2.7
-          - os: ubuntu-20.04
-            python: 3.7
+          - os: ubuntu-18.04
+            python: 3.6
       name: rospkg tests
       runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
The setup-python action has dropped 2.7 on macOS.
Aside from that, while it's possible for the exclude clause to be more
succinct in practice it has been more difficult to reason about.

The changes match those of [catkin_pkg#318].
One improvement is that this means that Python 3.6, the default Python
on Ubuntu 18.04 is actually tested on 18.04 although the setup-python
action does not use the upstream binaries as far as I can tell.
Python 3.7 testing on ubuntu-latest is meant to cover Debian Buster.

Beyond that the full changes are enumerated below

CI platforms before:
* ubuntu-18.04
  * python 2.7
  * python 3.7
  * python 3.8
  * python 3.9
* ubuntu-20.04
  * python 3.7
  * python 3.8
  * python 3.9
* macos-latest
  * python 2.7
  * python 3.7
  * python 3.8
  * python 3.9

CI platforms after:
* ubuntu-18.04
  * python 2.7
  * python 3.6
* ubuntu-20.04
  * python 3.7
  * python 3.8
  * python 3.9
* macos-latest
  * python 3.7
  * python 3.8
  * python 3.9

[catkin_pkg#318]: https://github.com/ros-infrastructure/catkin_pkg/pull/318