### PR TITLE
Update debian codename mapping

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -169,16 +169,17 @@ class Debian(LsbDetect):
 
     def get_codename(self):
         if self.is_os():
-            v = self.get_version()
-            if v.startswith('7.'):
-                return 'wheezy'
-            if v.startswith('8.'):
-                return 'jessie'
-            if v.startswith('9.'):
-                return 'stretch'
-            if v.startswith('10.'):
-                return 'buster'
-            return ''
+            v = self.get_version().split('.', 1)[0]
+            return {
+                '7': 'wheezy',
+                '8': 'jessie',
+                '9': 'stretch',
+                '10': 'buster',
+                '11': 'bullseye',
+                '12': 'bookworm',
+                '13': 'trixie',
+                'unstable': 'sid',
+            }.get(v, '')
 
 
 class FdoDetect(OsDetector):


### PR DESCRIPTION
A few issues here:
1. With py3.8, we're using 'distro' instead of 'platform', which gives us only the major version number. Using str.split handles both cases.
2. Add bookworm and trixie
3. Looks like 'sid' doesn't have a number, but that's okay

This should only result in a change in behavior for Debian versions newer than Buster. I tested it on Buster, Bullseye and Sid.