### PR TITLE
Use unittest.mock where possible

### DIFF
--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -34,8 +34,10 @@ from __future__ import absolute_import
 
 import os
 
-import mock
-from mock import patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 
 class TrueOs():
@@ -108,9 +110,9 @@ def test_LsbDetect():
     else:
         import platform as distro
 
-    distro.linux_distribution = mock.Mock()
+    distro.linux_distribution = Mock()
     distro.linux_distribution.return_value = ('Ubuntu', '10.04', 'lucid')
-    distro.dist = mock.Mock()
+    distro.dist = Mock()
     distro.dist.return_value = ('Ubuntu', '10.04', 'lucid')
 
     detect = LsbDetect('Ubuntu')


### PR DESCRIPTION
The 'unittest.mock' module has been present since Python 3.3, and some platforms are now dropping the 'mock' backport package.