### PR TITLE
Require distro 1.6.x with Python 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           if test ${{matrix.python}} = 2.7; then
-            python -m pip install pyparsing==2.4.7 'PyYAML<6.0'
+            python -m pip install 'distro<1.7.0' pyparsing==2.4.7 'PyYAML<6.0'
           fi
           python -m pip install --upgrade pip setuptools
           python -m pip install nose coverage mock

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ if (
     'SKIP_PYTHON_MODULES' not in os.environ and
     'SKIP_PYTHON_SCRIPTS' not in os.environ
 ):
-    install_requires.append('distro')
+    if sys.version_info[0] == 2:
+        install_requires.append('distro<1.7.0')
+    else:
+        install_requires.append('distro')
 
 kwargs = {
     'name': 'rospkg',


### PR DESCRIPTION
Support for Python 2 was [officially dropped in 1.7.0](https://github.com/python-distro/distro/blob/master/CHANGELOG.md#170-20220215).