### PR TITLE
Make dependency on distro specific to py3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if (
     'SKIP_PYTHON_MODULES' not in os.environ and
     'SKIP_PYTHON_SCRIPTS' not in os.environ
 ):
-    install_requires.append('distro')
+    install_requires.append("distro; python_version >= '3.8'")
 
 kwargs = {
     'name': 'rospkg',


### PR DESCRIPTION
The code only uses the `distro` module if using Python 3.8 and newer. The dependency should reflect that to avoid unnecessarily installing the dependency.