### PR TITLE
Enable Python 3.10 tests, bump actions/setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,26 +4,25 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ['*']
 
 jobs:
     build:
       strategy:
         matrix:
           os: [ubuntu-latest, macos-latest]
-          python: [3.7, 3.8, 3.9]
+          python: ['3.7', '3.8', '3.9', '3.10']
           include:
           - os: ubuntu-18.04
-            python: 2.7
+            python: '2.7'
           - os: ubuntu-18.04
-            python: 3.6
+            python: '3.6'
       name: rospkg tests
       runs-on: ${{matrix.os}}
 
       steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{matrix.python}}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python}}
       - name: Install dependencies


### PR DESCRIPTION
This also aligns the workflow better with catkin_pkg.