### PR TITLE
Run tests with pytest instead of nose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
             python -m pip install pyparsing==2.4.7 'PyYAML<6.0'
           fi
           python -m pip install --upgrade pip setuptools
-          python -m pip install nose coverage mock
+          python -m pip install mock pytest pytest-cov
           python setup.py build develop
       - name: Run tests
         run: |
-          python -m nose --with-coverage --cover-package=rospkg --with-xunit test
+          python -m pytest --cov=rospkg test

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ syntax: glob
 *~
 *.log
 .coverage
-nosetests.xml
 src/rospkg.egg-info
 syntax: regexp
 (target|build|dist)/.*

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ testsetup:
 	echo "running rospkg tests"
 
 test: testsetup
-	cd test && nosetests && nosetests3
+	cd test && pytest && pytest-3

--- a/doc/developers_guide.rst
+++ b/doc/developers_guide.rst
@@ -45,11 +45,11 @@ Setup
 
 ::
 
-    pip install nose
+    pip install pytest
     pip install mock
 
 
-rospkg uses `Python nose <http://readthedocs.org/docs/nose/en/latest/>`_ 
+rospkg uses `pytest <http://docs.pytest.org>`_ 
 for testing, which is a fairly simple and straightfoward test
 framework.  You just have to write a function start with the name
 ``test`` and use normal ``assert`` statements for your tests.
@@ -62,7 +62,7 @@ You can run the tests, including coverage, as follows:
 ::
 
     cd rospkg
-    nosetests test/*.py --with-coverage --cover-package=rospkg
+    pytest test --cov=rospkg
 
 
 Documentation

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,4 +1,0 @@
-[nosetests]
-with-coverage=1
-cover-package=rospkg
-with-xunit=1


### PR DESCRIPTION
Official nose documentation recommends users migrate to a more supported platform.

https://nose.readthedocs.io/en/latest/#note-to-users