### PR TITLE
Avoid use of deprecated function in distro module.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if (
     'SKIP_PYTHON_MODULES' not in os.environ and
     'SKIP_PYTHON_SCRIPTS' not in os.environ
 ):
-    install_requires.append("distro; python_version >= '3.8'")
+    install_requires.append("distro >= 1.4.0; python_version >= '3.8'")
 
 kwargs = {
     'name': 'rospkg',

--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -138,7 +138,9 @@ class LsbDetect(OsDetector):
     """
     def __init__(self, lsb_name, get_version_fn=None):
         self.lsb_name = lsb_name
-        if hasattr(distro, "linux_distribution"):
+        if distro.__name__ == "distro":
+            self.lsb_info = (distro.id(), distro.version(), distro.codename())
+        elif hasattr(distro, "linux_distribution"):
             self.lsb_info = distro.linux_distribution(full_distribution_name=0)
         elif hasattr(distro, "dist"):
             self.lsb_info = distro.dist()

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -18,7 +18,7 @@ Setup-Env-Vars: SKIP_PYTHON_MODULES=1
 
 [rospkg_modules]
 Depends: python-catkin-pkg-modules, python-yaml, lsb-release
-Depends3: python3-catkin-pkg-modules, python3-distro | python3 (<< 3.8), python3-yaml, lsb-release
+Depends3: python3-catkin-pkg-modules, python3-distro (>= 1.4.0) | python3 (<< 3.8), python3-yaml, lsb-release
 Conflicts: python-rospkg (<< 1.1.0)
 Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -110,10 +110,20 @@ def test_LsbDetect():
     else:
         import platform as distro
 
-    distro.linux_distribution = Mock()
-    distro.linux_distribution.return_value = ('Ubuntu', '10.04', 'lucid')
-    distro.dist = Mock()
-    distro.dist.return_value = ('Ubuntu', '10.04', 'lucid')
+    # Mock different interfaces based on the module used.
+    if distro.__name__ == 'distro':
+        distro.id = Mock()
+        distro.id.return_value = 'Ubuntu'
+        distro.version = Mock()
+        distro.version.return_value = '10.04'
+        distro.codename = Mock()
+        distro.codename.return_value = 'lucid'
+    elif hasattr(distro, 'linux_distribution'):
+        distro.linux_distribution = Mock()
+        distro.linux_distribution.return_value = ('Ubuntu', '10.04', 'lucid')
+    elif hasattr(distro, 'dist'):
+        distro.dist = Mock()
+        distro.dist.return_value = ('Ubuntu', '10.04', 'lucid')
 
     detect = LsbDetect('Ubuntu')
     assert detect.is_os(), "should be Ubuntu"


### PR DESCRIPTION
Recent versions of the distro module have deprecated the `distro.linux_distribution()` which is a compatibility shim for the
`platform.linux_distribution()` function removed in python 3.8.

All versions of the distro library going back to at least 1.0.1[1] packaged in Ubuntu Bionic[2] provide the `id`, `version`, and `codename` methods which are recommended instead.

`distro.id()` is used instead of `distro.name()` corresponding with the full_distribution_name=0 argument to `linux_distribution`.

When updating the tests to support this change I noticed that the mocks were being added in such a way that the `dist` conditional branch would never actually be tested. I didn't actually look at how far back we'd have to
go to find a platform module which did not support `linux_distribution` but it made sense to at least make testing that branch possible.

We'll have to take care that the `codename` member of the tuple continues to match what our scripts expect downstream since the tests mock the distro return values we don't have full coverage of the actual results on contemporary platforms.


Closes #241

[1]: https://github.com/python-distro/distro/blob/v1.0.1/
[2]: https://packages.ubuntu.com/bionic/python3-distro