### PR TITLE
Fix syntax error in Conda detector.

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -250,7 +250,7 @@ class Conda(OsDetector):
     Detect Conda.
     """
     def is_os(self):
-        return "ROS_OS_OVERRIDE" in os.environ and
+        return "ROS_OS_OVERRIDE" in os.environ and \
             (os.environ["ROS_OS_OVERRIDE"].lower().startswith("robostack") or
              os.environ["ROS_OS_OVERRIDE"].lower().startswith("conda"))
 


### PR DESCRIPTION
This slipped in from #224 since it was contributed while CI had other issues going on.

I think there are several different ways to structure this but this was the lightest touch. I'm not too particular if there are other style preferences.