### PR TITLE
Declare cov/junit module name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,4 @@ jobs:
           python setup.py build develop
       - name: Run tests
         run: |
-          python -m pytest --cov=rospkg test
+          python -m pytest --cov test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[tool:pytest]
+junit_suite_name = rospkg
+
+[coverage:run]
+source = rospkg


### PR DESCRIPTION
Using the `setup.cfg` to tell coverage the name of the module we're interested in is better than passing it on the command line every time we invoke pytest with `--cov`.

Declaring the `junit_suite_name` will make the tests categories correctly in our infrastructure.