### PR TITLE
Fasten rosversion --all

### DIFF
--- a/src/rospkg/rospack.py
+++ b/src/rospkg/rospack.py
@@ -44,6 +44,7 @@ from .manifest import InvalidManifest, parse_manifest_file
 from .stack import InvalidStack, parse_stack_file
 
 _cache_lock = Lock()
+path_cache = {}
 
 
 def list_by_path(manifest_name, path, cache):
@@ -68,7 +69,12 @@ def list_by_path(manifest_name, path, cache):
             continue  # leaf
         if PACKAGE_FILE in files:
             # parse package.xml and decide if it matches the search criteria
-            root = ElementTree(None, os.path.join(d, PACKAGE_FILE))
+            tmp_path = os.path.join(d, PACKAGE_FILE)
+            if tmp_path in path_cache:
+                root = path_cache[tmp_path]
+            else:
+                root = ElementTree(None, os.path.join(d, PACKAGE_FILE))
+                path_cache[tmp_path] = root
             is_metapackage = root.find('./export/metapackage') is not None
             if (
                 (manifest_name == STACK_FILE and is_metapackage) or


### PR DESCRIPTION
Faster `rosversion --all`.
The following is a comparison of execution times using pyinstrument.

- before (60.303s)
```
Program: /usr/bin/rosversion --all

60.303 main  rospkg/rosversion.py:95
└─ 60.235 get_version_from_package_name  rospkg/rosversion.py:72
   ├─ 30.819 get_path  rospkg/rospack.py:199
   │  └─ 30.819 _update_location_cache  rospkg/rospack.py:173
   │     └─ 30.811 list_by_path  rospkg/rospack.py:49
   │        ├─ 13.546 __init__  xml/etree/ElementTree.py:607
   │        │     [12 frames hidden]  xml, rospkg
   │        ├─ 10.886 walk  os.py:209
   │        │     [111 frames hidden]  os, rospkg, genericpath, stat, posixpath
   │        ├─ 3.090 [self]  
   │        └─ 2.749 find  xml/etree/ElementTree.py:694
   │              [18 frames hidden]  xml, rospkg
   └─ 29.178 get_stack_version  rospkg/rospack.py:421
      └─ 29.178 get_path  rospkg/rospack.py:199
         └─ 29.176 _update_location_cache  rospkg/rospack.py:173
            └─ 29.167 list_by_path  rospkg/rospack.py:49
               ├─ 13.520 __init__  xml/etree/ElementTree.py:607
               │     [12 frames hidden]  xml, rospkg
               ├─ 10.759 walk  os.py:209
               │     [110 frames hidden]  os, rospkg, genericpath, stat, posixpath
               ├─ 2.863 find  xml/etree/ElementTree.py:694
               │     [16 frames hidden]  xml, rospkg
               └─ 1.789 [self]  

```
- after (24.152s)
```
Program: /usr/bin/rosversion --all

24.152 main  rospkg/rosversion.py:95
└  24.047 get_version_from_package_name  rospkg/rosversion.py:72
   ├─ 12.760 get_path  rospkg/rospack.py:207
   │  └─ 12.759 _update_location_cache  rospkg/rospack.py:181
   │     └─ 12.753 list_by_path  rospkg/rospack.py:51
   │        ├─ 8.706 walk  os.py:209
   │        │     [114 frames hidden]  os, rospkg, genericpath, stat, posixpath
   │        ├─ 1.972 find  xml/etree/ElementTree.py:694
   │        │     [18 frames hidden]  xml, rospkg
   │        └─ 1.695 [self]  
   └─ 11.072 get_stack_version  rospkg/rospack.py:429
      └─ 11.069 get_path  rospkg/rospack.py:207
         └─ 11.066 _update_location_cache  rospkg/rospack.py:181
            └─ 11.065 list_by_path  rospkg/rospack.py:51
               ├─ 8.408 walk  os.py:209
               │     [106 frames hidden]  os, rospkg, genericpath, stat, posixpath
               ├─ 1.936 find  xml/etree/ElementTree.py:694
               │     [16 frames hidden]  xml, rospkg
               └─ 0.527 [self] 
```

cc:@iory @708yamaguchi