### PR TITLE
Add 'sles' using the "OS_OPENSUSE" tag

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -711,6 +711,7 @@ OsDetect.register_default(OS_OPENSUSE13, OpenSuse(brand_file='/etc/SUSE-brand', 
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-tumbleweed"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse-leap"))
 OsDetect.register_default(OS_OPENSUSE, FdoDetect("opensuse"))
+OsDetect.register_default(OS_OPENSUSE, FdoDetect("sles"))
 OsDetect.register_default(OS_ORACLE, FdoDetect("ol"))
 OsDetect.register_default(OS_CONDA, Conda())
 OsDetect.register_default(OS_TIZEN, FdoDetect("tizen"))


### PR DESCRIPTION
With the release of SLES 15 SP3, OpenSUSE and SUSE Linux Enterprise Server now share a common code base and are 100% binary compatible.Since the work has already been done to support OpenSUSE, lets just treat SLES as if it is OpenSUSE to reduce duplicated effort.

https://www.suse.com/c/introducing-suse-linux-enterprise-15-sp3/#:~:text=With%20the%20release%20of%20SLES,again%20%E2%80%93%20with%20assured%20application%20compatibility.

neotinker@ros-sles153:~/devel> cat /etc/os-release 
NAME="SLES"
VERSION="15-SP3"
VERSION_ID="15.3"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp3"
DOCUMENTATION_URL="https://documentation.suse.com/"
neotinker@ros-sles153:~/devel> 
