### PR TITLE
Add ventura in the _osx_codename_map

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -316,7 +316,8 @@ _osx_codename_map = {
  '10.14': 'mojave',
  '10.15': 'catalina',
  '11': 'big sur',
- '12': 'monterey'
+ '12': 'monterey',
+ '13': 'ventura'
 }
 
 


### PR DESCRIPTION
This PR will add the latest MacOS version/name in the map.