### PR TITLE
Report Debian 'rodete' as the current Debian testing codename

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -181,6 +181,7 @@ class Debian(LsbDetect):
                 '12': 'bookworm',
                 '13': 'trixie',
                 'unstable': 'sid',
+                'rodete': 'bookworm',
             }.get(v, '')
 
 


### PR DESCRIPTION
Debian Rodete, which stands for Rolling Debian Testing, is a build of Debian which will always target the current 'testing' distribution. At present, the codename associated with that channel is 'bookworm'.

As the testing codename changes we'll need to update it here. Alternatively, we could use an alias in `rosdep` to do this, but we need to update this mapping with each Debian release anyway, so it makes sense to do it here.

You can find more information on Debian Rodete here: https://cloud.google.com/blog/topics/developers-practitioners/how-google-got-to-rolling-linux-releases-for-desktops