### PR TITLE
Update deb platforms for release

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -11,7 +11,7 @@ Depends3: python3-rospkg-modules (>= 1.5.0)
 Conflicts: python3-rospkg
 Conflicts3: python-rospkg
 Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_MODULES=1
@@ -24,7 +24,7 @@ Conflicts3: python3-rospkg (<< 1.1.0)
 Replaces: python-rospkg (<< 1.1.0)
 Replaces3: python3-rospkg (<< 1.1.0)
 Suite: bionic buster
-Suite3: bionic focal jammy buster bullseye
+Suite3: focal jammy noble bookworm trixie
 Python2-Depends-Name: python
 X-Python3-Version: >= 3.4
 Setup-Env-Vars: SKIP_PYTHON_SCRIPTS=1


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Bookworm (stable)
* Debian Trixie (testing)

Dropped:
* Debian Buster (oldoldstable)
* Debian Bullseye (oldstable)
* Ubuntu Bionic (18.04 LTS)

Retained:
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)