### PR TITLE
Update debian codename mapping

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -180,8 +180,9 @@ class Debian(LsbDetect):
                 '11': 'bullseye',
                 '12': 'bookworm',
                 '13': 'trixie',
+                '14': 'forky',
                 'unstable': 'sid',
-                'rodete': 'bookworm',
+                'rodete': 'trixie',
             }.get(v, '')
 
 


### PR DESCRIPTION
* Debian 14 will be called 'Forky'
* Move 'Rodete' to 'Trixie' now that 'Bookworm' is stable