### PR TITLE
Run tests on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,6 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   pytest:
     uses: ros-infrastructure/ci/.github/workflows/pytest.yaml@main
-    with:
-      matrix-filter: del(.matrix.os[] | select(contains("windows")))
   yamllint:
     runs-on: ubuntu-latest
     steps:

--- a/test/test_rospkg_environment.py
+++ b/test/test_rospkg_environment.py
@@ -38,8 +38,9 @@ def test_get_ros_root():
     from rospkg import get_ros_root
     assert get_ros_root(env={}) is None
 
-    env = {'ROS_ROOT': '/fake/path'}
-    assert '/fake/path' == get_ros_root(env=env)
+    fake_path = os.path.normpath('/fake/path')
+    env = {'ROS_ROOT': fake_path}
+    assert fake_path == get_ros_root(env=env)
 
     real_ros_root = get_ros_root()
 
@@ -142,8 +143,8 @@ def test_compute_package_paths():
     assert compute_package_paths(None, 'bar') == ['bar'], compute_package_paths(None, 'bar')
     assert compute_package_paths('foo', '') == ['foo']
     assert compute_package_paths('foo', 'bar') == ['foo', 'bar']
-    assert compute_package_paths('foo', 'bar:bz') == ['foo', 'bar', 'bz']
-    assert compute_package_paths('foo', 'bar:bz::blah') == ['foo', 'bar', 'bz', 'blah']
+    assert compute_package_paths('foo', os.path.pathsep.join(('bar', 'bz'))) == ['foo', 'bar', 'bz']
+    assert compute_package_paths('foo', os.path.pathsep.join(('bar', 'bz', '', 'blah'))) == ['foo', 'bar', 'bz', 'blah']
 
 
 def test_resolve_path():

--- a/test/test_rospkg_manifest.py
+++ b/test/test_rospkg_manifest.py
@@ -177,7 +177,9 @@ def test_parse_manifest():
     from rospkg.manifest import MANIFEST_FILE, parse_manifest
     d = get_test_dir()
     p = os.path.join(d, 'example1', MANIFEST_FILE)
-    with open(p, 'r') as f:
+    # Open in binary mode to match the parse_manifest_file function
+    # This is particularly important on Windows
+    with open(p, 'rb') as f:
         contents = f.read()
     _subtest_parse_example1(parse_manifest(MANIFEST_FILE, contents, p))
 

--- a/test/test_rospkg_os_detect.py
+++ b/test/test_rospkg_os_detect.py
@@ -33,6 +33,7 @@
 from __future__ import absolute_import
 
 import os
+import sys
 
 try:
     from unittest.mock import Mock, patch
@@ -75,7 +76,7 @@ class FalseOs(object):
 
 def test__read_stdout():
     from rospkg.os_detect import _read_stdout
-    assert 'hello' == _read_stdout(['echo', 'hello'])
+    assert 'hello' == _read_stdout([sys.executable, '-c', "print('hello')"])
     assert _read_stdout(['bad-command-input-for-rospkg-os-detect']) is None
 
 


### PR DESCRIPTION
No changes to the package itself were necessary to get the tests to pass on Windows, just some updates to the tests themselves.