### PR TITLE
Add MacOS Sequoia to _osx_codename_map

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -321,6 +321,7 @@ _osx_codename_map = {
  '12': 'monterey',
  '13': 'ventura',
  '14': 'sonoma',
+ '15': 'sequoia',
 }
 
 


### PR DESCRIPTION
Add an additional version similar to [add macOS Sonoma to _osx_codename_map #262](https://github.com/ros-infrastructure/rospkg#262).

Output from `python3 -m rospkg.os_detect`:
```sh
OS Name:     osx
OS Version:  15.2
OS Codename: sequoia
```