### PR TITLE
Add 'Duke' to Debian codename mapping

### DIFF
--- a/src/rospkg/os_detect.py
+++ b/src/rospkg/os_detect.py
@@ -178,6 +178,7 @@ class Debian(LsbDetect):
                 '12': 'bookworm',
                 '13': 'trixie',
                 '14': 'forky',
+                '15': 'duke',
                 'unstable': 'sid',
                 'rodete': 'trixie',
             }.get(v, '')


### PR DESCRIPTION
Debian 15 will be called 'Duke'

https://lists.debian.org/debian-devel-announce/2025/01/msg00004.html